### PR TITLE
Use of ES6 classes - icons not working

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -20,6 +20,7 @@ Gettext.bindtextdomain(ME.metadata['gettext-domain'], ME.path + '/locale');
 
 const SIG_MANAGER = ME.imports.lib.signal_manager;
 const PANEL_ITEM  = ME.imports.lib.panel_item;
+const MISC_UTILS  = ME.imports.lib.misc_utils;
 
 
 // To add a section, add the module here, update the 'sections' entry in the
@@ -41,8 +42,6 @@ const PanelPosition = {
     CENTER : 1,
     RIGHT  : 2,
 };
-
-
 // =====================================================================
 // @@@ Main extension object
 // =====================================================================
@@ -207,7 +206,7 @@ var Timepp = GObject.registerClass({
             // unicon panel item (shown when single panel item mode is selected)
             //
             this.unicon_panel_item = new PANEL_ITEM.PanelItem(this.menu);
-            this.unicon_panel_item.icon.icon_name = 'timepp-unicon-symbolic';
+            this.unicon_panel_item.icon.gicon = MISC_UTILS.getIcon('timepp-unicon-symbolic');
 
             this.unicon_panel_item.set_mode('icon');
             this.unicon_panel_item.actor.add_style_class_name('unicon-panel-item');
@@ -653,29 +652,9 @@ function enable () {
             Main.panel.addToStatusArea('timepp', timepp, 0, 'right');
         }
     }
-
-    // To make it easier to use custom icons, we just append the img dir to the
-    // search paths of the default icon theme.
-    // To avoid issues, we prefix the file names of our custom symbolic icons
-    // with 'timepp-'.
-    {
-        let icon_theme = imports.gi.Gtk.IconTheme.get_default();
-        global.log("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
-        global.log(imports.misc.extensionUtils.getCurrentExtension().path)
-        icon_theme.prepend_search_path(ME.path + '/data/img/icons');
-    }
 }
 
 function disable () {
     timepp.destroy();
     timepp = null;
-
-    // remove the custom search path
-    {
-        let icon_theme  = imports.gi.Gtk.IconTheme.get_default();
-        let custom_path = ME.path + '/data/img/icons';
-        let paths       = icon_theme.get_search_path();
-        paths.splice(paths.indexOf(custom_path), 1);
-        icon_theme.set_search_path(paths);
-    }
 }

--- a/extension.js
+++ b/extension.js
@@ -7,8 +7,8 @@ const Main       = imports.ui.main;
 const PopupMenu  = imports.ui.popupMenu;
 const BoxPointer = imports.ui.boxpointer;
 const PanelMenu  = imports.ui.panelMenu;
-const Lang       = imports.lang;
 const Mainloop   = imports.mainloop;
+const GObject    = imports.gi.GObject
 
 
 const ME = imports.misc.extensionUtils.getCurrentExtension();
@@ -46,22 +46,19 @@ const PanelPosition = {
 // =====================================================================
 // @@@ Main extension object
 // =====================================================================
-const Timepp = new Lang.Class({
+/*const Timepp = new Lang.Class({
     Name    : 'Timepp.Timepp',
-    Extends : PanelMenu.Button,
-
-    _init: function () {
+    Extends : PanelMenu.Button,*/
+class Timepp extends PanelMenu.Button{
+    constructor() {
         // @HACK
         // This func only updates the max-height prop but not max-width.
         // We unset it and do our own thing.
         //
         // NOTE: Do this before calling the parent constructor because they use
         // bind() on the original func..
-        this._onOpenStateChanged = () => false;
-
-
-        this.parent(0.5, 'Timepp');
-
+        //this._onOpenStateChanged = () => false; //DO NOT KNOW WHAT TO DO
+        super(0.5, 'Timepp');
 
         // @SPEED @HACK
         // - We patch the menu.open function to emit the 'open-state-changed'
@@ -105,7 +102,6 @@ const Timepp = new Lang.Class({
                 });
             }
         };
-
 
         this.actor.style_class = '';
         this.actor.can_focus   = false;
@@ -260,9 +256,9 @@ const Timepp = new Lang.Class({
         this.sigm.connect(this.unicon_panel_item, 'right-click', () => this.toggle_context_menu());
         this.sigm.connect(this.unicon_panel_item.actor, 'enter-event', () => { if (Main.panel.menuManager.activeMenu) this.open_menu(); });
         this.sigm.connect(this.unicon_panel_item.actor, 'key-focus-in', () => this.open_menu());
-    },
+    }
 
-    _sync_sections_with_settings: function () {
+    _sync_sections_with_settings() {
         let sections = this.settings.get_value('sections').deep_unpack();
 
         for (let key in sections) {
@@ -300,12 +296,12 @@ const Timepp = new Lang.Class({
         }
 
         this.update_panel_items();
-    },
+    }
 
-    toggle_menu: function (section_name) {
+    toggle_menu(section_name) {
         if (this.menu.isOpen) this.menu.close(false);
         else                  this.open_menu(section_name);
-    },
+    }
 
     // @section: obj (a section's main object)
     //
@@ -317,7 +313,7 @@ const Timepp = new Lang.Class({
     //
     //     - If @section is not a sep menu, we show all joined sections that
     //       are enabled.
-    open_menu: function (section_name) {
+    open_menu(section_name) {
         let section = this.sections.get(section_name);
 
         if (this.menu.isOpen && section && section.actor.visible) return;
@@ -375,9 +371,9 @@ const Timepp = new Lang.Class({
 
         for (let s of shown_sections)  s.on_section_open_state_changed(true);
         for (let s of hidden_sections) s.on_section_open_state_changed(false);
-    },
+    }
 
-    toggle_context_menu: function (section_name) {
+    toggle_context_menu(section_name) {
         if (this.menu.isOpen) {
             this.menu.close(false);
             return;
@@ -402,10 +398,10 @@ const Timepp = new Lang.Class({
         this._update_menu_min_size();
         this._update_separators();
         this.menu.open();
-    },
+    }
 
     // PanelMenu only updates the min-height, we also need to update min-width.
-    _update_menu_min_size: function () {
+    _update_menu_min_size() {
         let work_area    = Main.layoutManager.getWorkAreaForMonitor(Main.layoutManager.findIndexForActor(this.menu.actor));
         let monitor      = Main.layoutManager.findMonitorForActor(this.menu.actor);
         let scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
@@ -425,14 +421,14 @@ const Timepp = new Lang.Class({
         this.menu_max_h = max_h;
 
         this.menu.actor.style = `max-height: ${max_h}px; max-width: ${max_w}px;`;
-    },
+    }
 
-    _update_menu_arrow: function (source_actor) {
+    _update_menu_arrow(source_actor) {
         this.menu._boxPointer.setPosition(source_actor, this.menu._arrowAlignment);
         this.menu.sourceActor = source_actor;
-    },
+    }
 
-    _update_separators: function () {
+    _update_separators() {
         let last_visible;
 
         for (let [k, sep] of this.separators) {
@@ -445,9 +441,9 @@ const Timepp = new Lang.Class({
         }
 
         if (last_visible) last_visible.hide();
-    },
+    }
 
-    _update_custom_css: function () {
+    _update_custom_css() {
         let update_needed = false;
         let theme_node    = this.panel_item_box.get_theme_node();
 
@@ -470,9 +466,9 @@ const Timepp = new Lang.Class({
         }
 
         if (update_needed) this.emit('custom-css-changed');
-    },
+    }
 
-    update_panel_items: function () {
+    update_panel_items() {
         if (this.settings.get_boolean('unicon-mode')) {
             let show_unicon = false;
 
@@ -493,9 +489,9 @@ const Timepp = new Lang.Class({
                 section.panel_item.actor.visible = true;
             }
         }
-    },
+    }
 
-    _on_panel_position_changed: function (old_pos, new_pos) {
+    _on_panel_position_changed(old_pos, new_pos) {
         let ref = this.container;
 
         switch (old_pos) {
@@ -520,9 +516,9 @@ const Timepp = new Lang.Class({
           case PanelPosition.RIGHT:
             Main.panel._rightBox.insert_child_at_index(ref, 0);
         }
-    },
+    }
 
-    _on_open_state_changed: function (state) {
+    _on_open_state_changed(state) {
         if (state) return Clutter.EVENT_PROPAGATE;
 
         this.context_menu.actor.hide();
@@ -540,14 +536,14 @@ const Timepp = new Lang.Class({
                 section.actor.visible = false;
             }
         }
-    },
+    }
 
-    _on_theme_changed: function () {
+    _on_theme_changed() {
         if (this.custom_stylesheet) this._unload_stylesheet();
         this._load_stylesheet();
-    },
+    }
 
-    _load_stylesheet: function () {
+    _load_stylesheet() {
         this.theme_change_signal_block = true;
 
         // determine custom stylesheet
@@ -576,9 +572,9 @@ const Timepp = new Lang.Class({
         Main.loadTheme();
 
         Mainloop.idle_add(() => this.theme_change_signal_block = false);
-    },
+    }
 
-    _unload_stylesheet: function () {
+    _unload_stylesheet() {
 
         if (! this.custom_stylesheet) return;
 
@@ -586,29 +582,29 @@ const Timepp = new Lang.Class({
             .unload_stylesheet(this.custom_stylesheet);
 
         this.custom_stylesheet = null;
-    },
+    }
 
-    is_section_enabled: function (section_name) {
+    is_section_enabled(section_name) {
         return this.sections.has(section_name);
-    },
+    }
 
     // Used by sections to communicate with each other.
     // This way any section can listen for signals on the main ext object.
-    emit_to_sections: function (sig, section_name, data) {
+    emit_to_sections(sig, section_name, data) {
         this.emit(sig, {section_name, data});
-    },
+    }
 
     // ScrollView always allocates horizontal space for the scrollbar when the
     // policy is set to AUTOMATIC. The result is an ugly padding on the right
     // when the scrollbar is invisible.
-    needs_scrollbar: function () {
+    needs_scrollbar() {
         let [, nat_h] = this.menu.actor.get_preferred_height(-1);
         let max_h     = this.menu.actor.get_theme_node().get_max_height();
 
         return max_h >= 0 && nat_h >= max_h;
-    },
+    }
 
-    destroy: function () {
+    destroy() {
         // We need to make sure that this one is set to the default actor or
         // else the shell will try to destroy the wrong panel actor.
         this._update_menu_arrow(this.actor);
@@ -621,9 +617,9 @@ const Timepp = new Lang.Class({
         this._unload_stylesheet();
         this.sigm.clear();
 
-        this.parent();
-    },
-});
+        super.destroy();
+    }
+}
 
 
 
@@ -636,7 +632,6 @@ let timepp;
 
 function enable () {
     timepp = new Timepp();
-
     {
         let pos;
 

--- a/extension.js
+++ b/extension.js
@@ -216,7 +216,6 @@ var Timepp = GObject.registerClass({
 
             this.panel_item_box.add_child(this.unicon_panel_item.actor);
 
-
             //
             // popup menu
             //
@@ -661,6 +660,8 @@ function enable () {
     // with 'timepp-'.
     {
         let icon_theme = imports.gi.Gtk.IconTheme.get_default();
+        global.log("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        global.log(imports.misc.extensionUtils.getCurrentExtension().path)
         icon_theme.prepend_search_path(ME.path + '/data/img/icons');
     }
 }

--- a/extension.js
+++ b/extension.js
@@ -49,16 +49,21 @@ const PanelPosition = {
 /*const Timepp = new Lang.Class({
     Name    : 'Timepp.Timepp',
     Extends : PanelMenu.Button,*/
-var Timepp = GObject.registerClass(
-    class Timepp extends PanelMenu.Button{
-        _init() {
+var Timepp = GObject.registerClass({
+    Signals: {
+        'custom-css-changed': {},
+        'start-time-tracking-by-id': {},
+        'stop-time-tracking-by-id': {}
+    }
+},  class Timepp extends PanelMenu.Button{
+            _init() {
             // @HACK
             // This func only updates the max-height prop but not max-width.
             // We unset it and do our own thing.
             //
             // NOTE: Do this before calling the parent constructor because they use
             // bind() on the original func..
-            this._onOpenStateChanged = () => false; //DO NOT KNOW WHAT TO DO
+            this._onOpenStateChanged = () => false;
             super._init(0.5, 'Timepp');
 
             // @SPEED @HACK
@@ -90,11 +95,11 @@ var Timepp = GObject.registerClass(
                 // If there is another menu open, we emit 'open-state-changed' the
                 // normal way to avoid any deadlocks.
                 if (Main.panel.menuManager.activeMenu) {
-                    this._boxPointer.show(BoxPointer.PopupAnimation.FULL);
+                    this._boxPointer.open(BoxPointer.PopupAnimation.FULL);
                     this.emit('open-state-changed', true);
                 } else {
                     // Put in boxpointer callback to play nicely with animations.
-                    this._boxPointer.show(BoxPointer.PopupAnimation.FULL, () => {
+                    this._boxPointer.open(BoxPointer.PopupAnimation.FULL, () => {
                         let f = global.stage.get_key_focus();
                         Mainloop.timeout_add(0, () => {
                             this.emit('open-state-changed', true);
@@ -187,7 +192,6 @@ var Timepp = GObject.registerClass(
             this.custom_stylesheet   = null;
 
             this.theme_change_signal_block = false;
-
 
             // ensure cache dir
             {
@@ -466,7 +470,7 @@ var Timepp = GObject.registerClass(
                 }
             }
 
-            //if (update_needed) this.emit('custom-css-changed');
+            if (update_needed) this.emit('custom-css-changed');
         }
 
         update_panel_items() {

--- a/extension.js
+++ b/extension.js
@@ -49,577 +49,579 @@ const PanelPosition = {
 /*const Timepp = new Lang.Class({
     Name    : 'Timepp.Timepp',
     Extends : PanelMenu.Button,*/
-class Timepp extends PanelMenu.Button{
-    constructor() {
-        // @HACK
-        // This func only updates the max-height prop but not max-width.
-        // We unset it and do our own thing.
-        //
-        // NOTE: Do this before calling the parent constructor because they use
-        // bind() on the original func..
-        //this._onOpenStateChanged = () => false; //DO NOT KNOW WHAT TO DO
-        super(0.5, 'Timepp');
-
-        // @SPEED @HACK
-        // - We patch the menu.open function to emit the 'open-state-changed'
-        //   in a timeout.
-        // - We remove the raise_top() func which causes a lot of lag and seems
-        //   to be useless anyway.
-        this.menu.open = function () {
-            if (this.isOpen) return;
-            this.isOpen = true;
-
+var Timepp = GObject.registerClass(
+    class Timepp extends PanelMenu.Button{
+        _init() {
             // @HACK
-            // If an extension puts the panel to the bottom and updates the
-            // _arrowSide prop, then the func _updateFlip() in boxpointer will
-            // call _calculateArrowSide() and reset that prop if the menu is
-            // higher than the monitor.
-            // This will lead to the menu not being shown because it will be
-            // rendered below the panel.
+            // This func only updates the max-height prop but not max-width.
+            // We unset it and do our own thing.
             //
-            // I don't understand what the point of _calculateArrowSide() is..
-            //
-            // Since we patch the open() func, we have to include this hack here.
-            let panel_pos = Main.layoutManager.panelBox.anchor_y == 0 ? St.Side.TOP : St.Side.BOTTOM;
-            this._boxPointer._userArrowSide = panel_pos;
-            this._boxPointer._arrowSide     = panel_pos;
+            // NOTE: Do this before calling the parent constructor because they use
+            // bind() on the original func..
+            this._onOpenStateChanged = () => false; //DO NOT KNOW WHAT TO DO
+            super._init(0.5, 'Timepp');
 
-            this._boxPointer.setPosition(this.sourceActor, this._arrowAlignment);
+            // @SPEED @HACK
+            // - We patch the menu.open function to emit the 'open-state-changed'
+            //   in a timeout.
+            // - We remove the raise_top() func which causes a lot of lag and seems
+            //   to be useless anyway.
+            this.menu.open = function () {
+                if (this.isOpen) return;
+                this.isOpen = true;
 
-            // If there is another menu open, we emit 'open-state-changed' the
-            // normal way to avoid any deadlocks.
-            if (Main.panel.menuManager.activeMenu) {
-                this._boxPointer.show(BoxPointer.PopupAnimation.FULL);
-                this.emit('open-state-changed', true);
-            } else {
-                // Put in boxpointer callback to play nicely with animations.
-                this._boxPointer.show(BoxPointer.PopupAnimation.FULL, () => {
-                    let f = global.stage.get_key_focus();
-                    Mainloop.timeout_add(0, () => {
-                        this.emit('open-state-changed', true);
-                        f.grab_key_focus();
+                // @HACK
+                // If an extension puts the panel to the bottom and updates the
+                // _arrowSide prop, then the func _updateFlip() in boxpointer will
+                // call _calculateArrowSide() and reset that prop if the menu is
+                // higher than the monitor.
+                // This will lead to the menu not being shown because it will be
+                // rendered below the panel.
+                //
+                // I don't understand what the point of _calculateArrowSide() is..
+                //
+                // Since we patch the open() func, we have to include this hack here.
+                let panel_pos = Main.layoutManager.panelBox.anchor_y == 0 ? St.Side.TOP : St.Side.BOTTOM;
+                this._boxPointer._userArrowSide = panel_pos;
+                this._boxPointer._arrowSide     = panel_pos;
+
+                this._boxPointer.setPosition(this.sourceActor, this._arrowAlignment);
+
+                // If there is another menu open, we emit 'open-state-changed' the
+                // normal way to avoid any deadlocks.
+                if (Main.panel.menuManager.activeMenu) {
+                    this._boxPointer.show(BoxPointer.PopupAnimation.FULL);
+                    this.emit('open-state-changed', true);
+                } else {
+                    // Put in boxpointer callback to play nicely with animations.
+                    this._boxPointer.show(BoxPointer.PopupAnimation.FULL, () => {
+                        let f = global.stage.get_key_focus();
+                        Mainloop.timeout_add(0, () => {
+                            this.emit('open-state-changed', true);
+                            f.grab_key_focus();
+                        });
                     });
-                });
-            }
-        };
-
-        this.actor.style_class = '';
-        this.actor.can_focus   = false;
-        this.actor.reactive    = false;
-        this.menu.actor.add_style_class_name('timepp-menu');
-
-
-        this.panel_item_box = new St.BoxLayout({ style_class: 'timepp-panel-box timepp-custom-css-root'});
-        this.actor.add_actor(this.panel_item_box);
-
-
-        this.markdown_map = new Map([
-            ['`'   , ['', '']],
-            ['``'  , ['<tt>', '</tt>']],
-
-            ['*'   , ['<b>', '</b>']],
-            ['**'  , ['<i>', '</i>']],
-            ['***' , ['<b><span foreground="black" background="#e74f4f">', '</span></b>']],
-
-            ['_'   , null],
-            ['__'  , ['<i>', '</i>']],
-            ['___' , ['<u>', '</u>']],
-
-            ['~'   , null],
-            ['~~'  , ['<s>', '</s>']],
-
-            ['#'   , ['<span size="xx-large">', '</span>']],
-            ['##'  , ['<span size="x-large">', '</span>']],
-            ['###' , ['<span size="large">', '</span>']],
-        ]);
-
-
-        this.custom_css = {
-            ['-timepp-link-color']       : ['blue'    , [0, 0, 1, 1]],
-
-            ['-timepp-context-color']    : ['magenta' , [1, 0, 1, 1]],
-            ['-timepp-due-date-color']   : ['red'     , [1, 0, 0, 1]],
-            ['-timepp-project-color']    : ['green'   , [0, 1, 0, 1]],
-            ['-timepp-rec-date-color']   : ['tomato'  , [1, .38, .28, 1]],
-            ['-timepp-defer-date-color'] : ['violet'  , [.93, .51, .93, 1]],
-
-            ['-timepp-axes-color']       : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-y-label-color']    : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-x-label-color']    : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-rulers-color']     : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-proj-vbar-color']  : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-task-vbar-color']  : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-vbar-bg-color']    : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-heatmap-color-A']  : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-heatmap-color-B']  : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-heatmap-color-C']  : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-heatmap-color-D']  : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-heatmap-color-E']  : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-heatmap-color-F']  : ['white'   , [1, 1, 1, 1]],
-            ['-timepp-heatmap-selected-color'] : ['white', [1, 1, 1, 1]],
-        };
-
-
-        {
-            let GioSSS = Gio.SettingsSchemaSource;
-            let schema = GioSSS.new_from_directory(
-                ME.path + '/data/schemas', GioSSS.get_default(), false);
-            schema = schema.lookup('org.gnome.shell.extensions.timepp', false);
-
-            this.settings = new Gio.Settings({ settings_schema: schema });
-        }
-
-
-        // @key: string (a section name)
-        // @val: object (an instantiated main section object)
-        //
-        // This map only holds sections that are currently enabled.
-        this.sections = new Map();
-
-        // @key: string (a section name)
-        // @val: object (a PopupSeparatorMenuItem().actor)
-        this.separators = new Map();
-
-
-        this.sigm                = new SIG_MANAGER.SignalManager();
-        this.panel_item_position = this.settings.get_enum('panel-item-position');
-        this.custom_stylesheet   = null;
-
-        this.theme_change_signal_block = false;
-
-
-        // ensure cache dir
-        {
-            let dir = Gio.file_new_for_path(
-                `${GLib.get_home_dir()}/.cache/timepp_gnome_shell_extension`);
-
-            if (!dir.query_exists(null))
-                dir.make_directory_with_parents(null);
-        }
-
-
-        //
-        // unicon panel item (shown when single panel item mode is selected)
-        //
-        this.unicon_panel_item = new PANEL_ITEM.PanelItem(this.menu);
-        this.unicon_panel_item.icon.icon_name = 'timepp-unicon-symbolic';
-
-        this.unicon_panel_item.set_mode('icon');
-        this.unicon_panel_item.actor.add_style_class_name('unicon-panel-item');
-
-        if (! this.settings.get_boolean('unicon-mode')) this.unicon_panel_item.actor.hide();
-
-        this.panel_item_box.add_child(this.unicon_panel_item.actor);
-
-
-        //
-        // popup menu
-        //
-        this.content_box = new St.BoxLayout({ style_class: 'timepp-content-box', vertical: true});
-        this.menu.box.add_child(this.content_box);
-        this.content_box._delegate = this;
-
-
-        //
-        // context menu
-        //
-        this.context_menu = new ContextMenu.ContextMenu(this);
-        this.content_box.add_actor(this.context_menu.actor);
-        this.context_menu.actor.hide();
-
-
-        //
-        // more init
-        //
-        this._sync_sections_with_settings();
-        this.update_panel_items();
-        Mainloop.idle_add(() => this._load_stylesheet());
-
-
-        //
-        // listen
-        //
-        this.sigm.connect(St.ThemeContext.get_for_stage(global.stage), 'changed', () => {
-            if (this.theme_change_signal_block) return;
-            this._on_theme_changed();
-        });
-        this.sigm.connect(this.settings, 'changed::panel-item-position', () => {
-            let new_val = this.settings.get_enum('panel-item-position');
-            this._on_panel_position_changed(this.panel_item_position, new_val);
-            this.panel_item_position = new_val;
-        });
-        this.sigm.connect(this.settings, 'changed::sections', () => this._sync_sections_with_settings());
-        this.sigm.connect(this.settings, 'changed::unicon-mode', () => this.update_panel_items());
-        this.sigm.connect(this.panel_item_box, 'style-changed', () => this._update_custom_css());
-        this.sigm.connect(this.menu, 'open-state-changed', (_, state) => this._on_open_state_changed(state));
-        this.sigm.connect(this.unicon_panel_item, 'left-click', () => this.toggle_menu());
-        this.sigm.connect(this.unicon_panel_item, 'right-click', () => this.toggle_context_menu());
-        this.sigm.connect(this.unicon_panel_item.actor, 'enter-event', () => { if (Main.panel.menuManager.activeMenu) this.open_menu(); });
-        this.sigm.connect(this.unicon_panel_item.actor, 'key-focus-in', () => this.open_menu());
-    }
-
-    _sync_sections_with_settings() {
-        let sections = this.settings.get_value('sections').deep_unpack();
-
-        for (let key in sections) {
-            if (! sections.hasOwnProperty(key)) continue;
-
-            if (sections[key].enabled) {
-                if (! this.sections.has(key)) {
-                    let module = SECTIONS.get(key);
-                    let section = new module.SectionMain(key, this, this.settings);
-
-                    this.sections.set(key, section);
-                    section.actor.hide();
-                    this.content_box.add_child(section.actor);
-
-                    this.panel_item_box.add_child(section.panel_item.actor);
-
-                    let sep = new PopupMenu.PopupSeparatorMenuItem();
-                    sep.actor.add_style_class_name('timepp-separator');
-                    this.content_box.add_child(sep.actor);
-                    this.separators.set(key, sep.actor);
                 }
-            } else if (this.sections.has(key)) {
-                let s = this.sections.get(key);
+            };
 
-                // The current sourceActor could be the panel_item of the section
-                // we are about to disable which destroys panel_item.
-                if (s.panel_item.actor === this.menu.sourceActor)
-                    this._update_menu_arrow(this.actor);
+            this.actor.style_class = '';
+            this.actor.can_focus   = false;
+            this.actor.reactive    = false;
+            this.menu.actor.add_style_class_name('timepp-menu');
 
-                s.disable_section();
-                this.sections.delete(key);
-                this.separators.get(key).destroy();
-                this.separators.delete(key);
+
+            this.panel_item_box = new St.BoxLayout({ style_class: 'timepp-panel-box timepp-custom-css-root'});
+            this.actor.add_actor(this.panel_item_box);
+
+
+            this.markdown_map = new Map([
+                ['`'   , ['', '']],
+                ['``'  , ['<tt>', '</tt>']],
+
+                ['*'   , ['<b>', '</b>']],
+                ['**'  , ['<i>', '</i>']],
+                ['***' , ['<b><span foreground="black" background="#e74f4f">', '</span></b>']],
+
+                ['_'   , null],
+                ['__'  , ['<i>', '</i>']],
+                ['___' , ['<u>', '</u>']],
+
+                ['~'   , null],
+                ['~~'  , ['<s>', '</s>']],
+
+                ['#'   , ['<span size="xx-large">', '</span>']],
+                ['##'  , ['<span size="x-large">', '</span>']],
+                ['###' , ['<span size="large">', '</span>']],
+            ]);
+
+
+            this.custom_css = {
+                ['-timepp-link-color']       : ['blue'    , [0, 0, 1, 1]],
+
+                ['-timepp-context-color']    : ['magenta' , [1, 0, 1, 1]],
+                ['-timepp-due-date-color']   : ['red'     , [1, 0, 0, 1]],
+                ['-timepp-project-color']    : ['green'   , [0, 1, 0, 1]],
+                ['-timepp-rec-date-color']   : ['tomato'  , [1, .38, .28, 1]],
+                ['-timepp-defer-date-color'] : ['violet'  , [.93, .51, .93, 1]],
+
+                ['-timepp-axes-color']       : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-y-label-color']    : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-x-label-color']    : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-rulers-color']     : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-proj-vbar-color']  : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-task-vbar-color']  : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-vbar-bg-color']    : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-heatmap-color-A']  : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-heatmap-color-B']  : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-heatmap-color-C']  : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-heatmap-color-D']  : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-heatmap-color-E']  : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-heatmap-color-F']  : ['white'   , [1, 1, 1, 1]],
+                ['-timepp-heatmap-selected-color'] : ['white', [1, 1, 1, 1]],
+            };
+
+
+            {
+                let GioSSS = Gio.SettingsSchemaSource;
+                let schema = GioSSS.new_from_directory(
+                    ME.path + '/data/schemas', GioSSS.get_default(), false);
+                schema = schema.lookup('org.gnome.shell.extensions.timepp', false);
+
+                this.settings = new Gio.Settings({ settings_schema: schema });
             }
+
+
+            // @key: string (a section name)
+            // @val: object (an instantiated main section object)
+            //
+            // This map only holds sections that are currently enabled.
+            this.sections = new Map();
+
+            // @key: string (a section name)
+            // @val: object (a PopupSeparatorMenuItem().actor)
+            this.separators = new Map();
+
+
+            this.sigm                = new SIG_MANAGER.SignalManager();
+            this.panel_item_position = this.settings.get_enum('panel-item-position');
+            this.custom_stylesheet   = null;
+
+            this.theme_change_signal_block = false;
+
+
+            // ensure cache dir
+            {
+                let dir = Gio.file_new_for_path(
+                    `${GLib.get_home_dir()}/.cache/timepp_gnome_shell_extension`);
+
+                if (!dir.query_exists(null))
+                    dir.make_directory_with_parents(null);
+            }
+
+
+            //
+            // unicon panel item (shown when single panel item mode is selected)
+            //
+            this.unicon_panel_item = new PANEL_ITEM.PanelItem(this.menu);
+            this.unicon_panel_item.icon.icon_name = 'timepp-unicon-symbolic';
+
+            this.unicon_panel_item.set_mode('icon');
+            this.unicon_panel_item.actor.add_style_class_name('unicon-panel-item');
+
+            if (! this.settings.get_boolean('unicon-mode')) this.unicon_panel_item.actor.hide();
+
+            this.panel_item_box.add_child(this.unicon_panel_item.actor);
+
+
+            //
+            // popup menu
+            //
+            this.box_content = new St.BoxLayout({ style_class: 'timepp-content-box', vertical: true});
+            this.menu.box.add_child(this.box_content);
+            this.box_content._delegate = this;
+
+
+            //
+            // context menu
+            //
+            this.context_menu = new ContextMenu.ContextMenu(this);
+            this.box_content.add_actor(this.context_menu.actor);
+            this.context_menu.actor.hide();
+
+
+            //
+            // more init
+            //
+            this._sync_sections_with_settings();
+            this.update_panel_items();
+            Mainloop.idle_add(() => this._load_stylesheet());
+
+
+            //
+            // listen
+            //
+            this.sigm.connect(St.ThemeContext.get_for_stage(global.stage), 'changed', () => {
+                if (this.theme_change_signal_block) return;
+                this._on_theme_changed();
+            });
+            this.sigm.connect(this.settings, 'changed::panel-item-position', () => {
+                let new_val = this.settings.get_enum('panel-item-position');
+                this._on_panel_position_changed(this.panel_item_position, new_val);
+                this.panel_item_position = new_val;
+            });
+            this.sigm.connect(this.settings, 'changed::sections', () => this._sync_sections_with_settings());
+            this.sigm.connect(this.settings, 'changed::unicon-mode', () => this.update_panel_items());
+            this.sigm.connect(this.panel_item_box, 'style-changed', () => this._update_custom_css());
+            this.sigm.connect(this.menu, 'open-state-changed', (_, state) => this._on_open_state_changed(state));
+            this.sigm.connect(this.unicon_panel_item, 'left-click', () => this.toggle_menu());
+            this.sigm.connect(this.unicon_panel_item, 'right-click', () => this.toggle_context_menu());
+            this.sigm.connect(this.unicon_panel_item.actor, 'enter-event', () => { if (Main.panel.menuManager.activeMenu) this.open_menu(); });
+            this.sigm.connect(this.unicon_panel_item.actor, 'key-focus-in', () => this.open_menu());
         }
 
-        this.update_panel_items();
-    }
+        _sync_sections_with_settings() {
+            let sections = this.settings.get_value('sections').deep_unpack();
 
-    toggle_menu(section_name) {
-        if (this.menu.isOpen) this.menu.close(false);
-        else                  this.open_menu(section_name);
-    }
+            for (let key in sections) {
+                if (! sections.hasOwnProperty(key)) continue;
 
-    // @section: obj (a section's main object)
-    //
-    // - If @section is null, then that is assumed to mean that the unicon icon
-    //   has been clicked/activated (i.e., we show all joined menus.)
-    //
-    // - If @section is provided, then the menu will open to show that section.
-    //     - If @section is a separate menu, we show it and hide all other menus.
-    //
-    //     - If @section is not a sep menu, we show all joined sections that
-    //       are enabled.
-    open_menu(section_name) {
-        let section = this.sections.get(section_name);
+                if (sections[key].enabled) {
+                    if (! this.sections.has(key)) {
+                        let module = SECTIONS.get(key);
+                        let section = new module.SectionMain(key, this, this.settings);
 
-        if (this.menu.isOpen && section && section.actor.visible) return;
-        if (this.context_menu.actor.visible) return;
+                        this.sections.set(key, section);
+                        section.actor.hide();
+                        this.box_content.add_child(section.actor);
 
-        this.unicon_panel_item.actor.remove_style_pseudo_class('checked');
-        this.unicon_panel_item.actor.remove_style_pseudo_class('focus');
-        this.unicon_panel_item.actor.can_focus = true;
+                        this.panel_item_box.add_child(section.panel_item.actor);
 
-        // Track sections whose state has changed and call their
-        // on_section_open_state_changed method after the menu has been shown.
-        let shown_sections  = [];
-        let hidden_sections = [];
+                        let sep = new PopupMenu.PopupSeparatorMenuItem();
+                        sep.actor.add_style_class_name('timepp-separator');
+                        this.box_content.add_child(sep.actor);
+                        this.separators.set(key, sep.actor);
+                    }
+                } else if (this.sections.has(key)) {
+                    let s = this.sections.get(key);
 
-        if (!section || !section.separate_menu) {
-            if (this.unicon_panel_item.actor.visible) {
-                this._update_menu_arrow(this.unicon_panel_item.actor);
-                this.unicon_panel_item.actor.add_style_pseudo_class('checked');
-                this.unicon_panel_item.actor.can_focus = false;
-            } else {
-                this._update_menu_arrow(section.panel_item.actor);
+                    // The current sourceActor could be the panel_item of the section
+                    // we are about to disable which destroys panel_item.
+                    if (s.panel_item.actor === this.menu.sourceActor)
+                        this._update_menu_arrow(this.actor);
+
+                    s.disable_section();
+                    this.sections.delete(key);
+                    this.separators.get(key).destroy();
+                    this.separators.delete(key);
+                }
             }
 
-            for (let [, section] of this.sections) {
-                if (section.separate_menu) {
-                    if (section.actor.visible) {
-                        hidden_sections.push(section);
-                        section.actor.hide();
+            this.update_panel_items();
+        }
+
+        toggle_menu(section_name) {
+            if (this.menu.isOpen) this.menu.close(false);
+            else                  this.open_menu(section_name);
+        }
+
+        // @section: obj (a section's main object)
+        //
+        // - If @section is null, then that is assumed to mean that the unicon icon
+        //   has been clicked/activated (i.e., we show all joined menus.)
+        //
+        // - If @section is provided, then the menu will open to show that section.
+        //     - If @section is a separate menu, we show it and hide all other menus.
+        //
+        //     - If @section is not a sep menu, we show all joined sections that
+        //       are enabled.
+        open_menu(section_name) {
+            let section = this.sections.get(section_name);
+
+            if (this.menu.isOpen && section && section.actor.visible) return;
+            if (this.context_menu.actor.visible) return;
+
+            this.unicon_panel_item.actor.remove_style_pseudo_class('checked');
+            this.unicon_panel_item.actor.remove_style_pseudo_class('focus');
+            this.unicon_panel_item.actor.can_focus = true;
+
+            // Track sections whose state has changed and call their
+            // on_section_open_state_changed method after the menu has been shown.
+            let shown_sections  = [];
+            let hidden_sections = [];
+
+            if (!section || !section.separate_menu) {
+                if (this.unicon_panel_item.actor.visible) {
+                    this._update_menu_arrow(this.unicon_panel_item.actor);
+                    this.unicon_panel_item.actor.add_style_pseudo_class('checked');
+                    this.unicon_panel_item.actor.can_focus = false;
+                } else {
+                    this._update_menu_arrow(section.panel_item.actor);
+                }
+
+                for (let [, section] of this.sections) {
+                    if (section.separate_menu) {
+                        if (section.actor.visible) {
+                            hidden_sections.push(section);
+                            section.actor.hide();
+                        }
+                    } else if (! section.actor.visible) {
+                        shown_sections.push(section);
+                        section.actor.visible = true;
                     }
-                } else if (! section.actor.visible) {
+                }
+            } else if (section.separate_menu) {
+                this._update_menu_arrow(section.panel_item.actor);
+
+                if (! section.actor.visible) {
                     shown_sections.push(section);
                     section.actor.visible = true;
                 }
-            }
-        } else if (section.separate_menu) {
-            this._update_menu_arrow(section.panel_item.actor);
 
-            if (! section.actor.visible) {
-                shown_sections.push(section);
-                section.actor.visible = true;
-            }
+                for (let [, section] of this.sections) {
+                    if (section_name === section.section_name ||
+                        !section.actor.visible) continue;
 
-            for (let [, section] of this.sections) {
-                if (section_name === section.section_name ||
-                    !section.actor.visible) continue;
-
-                hidden_sections.push(section);
-                section.actor.visible = false;
-            }
-        }
-
-        this._update_menu_min_size();
-        this._update_separators();
-        this.menu.open();
-
-        for (let s of shown_sections)  s.on_section_open_state_changed(true);
-        for (let s of hidden_sections) s.on_section_open_state_changed(false);
-    }
-
-    toggle_context_menu(section_name) {
-        if (this.menu.isOpen) {
-            this.menu.close(false);
-            return;
-        }
-
-        let section = this.sections.get(section_name);
-
-        if (section) this._update_menu_arrow(section.panel_item.actor);
-        else         this._update_menu_arrow(this.unicon_panel_item.actor);
-
-        this.context_menu.actor.visible = true;
-        this.unicon_panel_item.actor.add_style_pseudo_class('checked');
-        this.unicon_panel_item.actor.can_focus = false;
-
-        for (let [, section] of this.sections) {
-            if (section.panel_item.actor.visible) {
-                section.panel_item.actor.add_style_pseudo_class('checked');
-                section.panel_item.actor.can_focus = false;
-            }
-        }
-
-        this._update_menu_min_size();
-        this._update_separators();
-        this.menu.open();
-    }
-
-    // PanelMenu only updates the min-height, we also need to update min-width.
-    _update_menu_min_size() {
-        let work_area    = Main.layoutManager.getWorkAreaForMonitor(Main.layoutManager.findIndexForActor(this.menu.actor));
-        let monitor      = Main.layoutManager.findMonitorForActor(this.menu.actor);
-        let scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
-
-        // @HACK
-        // Some extensions enable autohiding of the panel and as a result the
-        // height of the panel is not taken into account when computing the
-        // work area. This is just a simple work around.
-        let tweak = 16;
-        if (monitor.height === work_area.height)
-            tweak = Main.layoutManager.panelBox.height + tweak;
-
-        let max_h = Math.floor((work_area.height - tweak) / scale_factor);
-        let max_w = Math.floor((work_area.width  - 16) / scale_factor);
-
-        this.menu_max_w = max_w;
-        this.menu_max_h = max_h;
-
-        this.menu.actor.style = `max-height: ${max_h}px; max-width: ${max_w}px;`;
-    }
-
-    _update_menu_arrow(source_actor) {
-        this.menu._boxPointer.setPosition(source_actor, this.menu._arrowAlignment);
-        this.menu.sourceActor = source_actor;
-    }
-
-    _update_separators() {
-        let last_visible;
-
-        for (let [k, sep] of this.separators) {
-            if (this.sections.get(k).actor.visible) {
-                last_visible = sep;
-                sep.show();
-            } else {
-                sep.hide();
-            }
-        }
-
-        if (last_visible) last_visible.hide();
-    }
-
-    _update_custom_css() {
-        let update_needed = false;
-        let theme_node    = this.panel_item_box.get_theme_node();
-
-        for (let prop in this.custom_css) {
-            if (! this.custom_css.hasOwnProperty(prop)) continue;
-
-            let [success, col] = theme_node.lookup_color(prop, false);
-            let hex            = col.to_string();
-
-            if (success && this.custom_css[prop][0] !== hex) {
-                update_needed = true;
-
-                this.custom_css[prop] = [hex, [
-                    col.red   / 255,
-                    col.green / 255,
-                    col.blue  / 255,
-                    col.alpha / 255,
-                ]];
-            }
-        }
-
-        if (update_needed) this.emit('custom-css-changed');
-    }
-
-    update_panel_items() {
-        if (this.settings.get_boolean('unicon-mode')) {
-            let show_unicon = false;
-
-            for (let [, section] of this.sections) {
-                if (section.separate_menu) {
-                    section.panel_item.actor.show();
-                } else {
-                    section.panel_item.actor.hide();
-                    show_unicon = true;
+                    hidden_sections.push(section);
+                    section.actor.visible = false;
                 }
             }
 
-            this.unicon_panel_item.actor.visible = show_unicon;
-        } else {
-            this.unicon_panel_item.actor.hide();
+            this._update_menu_min_size();
+            this._update_separators();
+            this.menu.open();
+
+            for (let s of shown_sections)  s.on_section_open_state_changed(true);
+            for (let s of hidden_sections) s.on_section_open_state_changed(false);
+        }
+
+        toggle_context_menu(section_name) {
+            if (this.menu.isOpen) {
+                this.menu.close(false);
+                return;
+            }
+
+            let section = this.sections.get(section_name);
+
+            if (section) this._update_menu_arrow(section.panel_item.actor);
+            else         this._update_menu_arrow(this.unicon_panel_item.actor);
+
+            this.context_menu.actor.visible = true;
+            this.unicon_panel_item.actor.add_style_pseudo_class('checked');
+            this.unicon_panel_item.actor.can_focus = false;
 
             for (let [, section] of this.sections) {
-                section.panel_item.actor.visible = true;
-            }
-        }
-    }
-
-    _on_panel_position_changed(old_pos, new_pos) {
-        let ref = this.container;
-
-        switch (old_pos) {
-          case PanelPosition.LEFT:
-            Main.panel._leftBox.remove_child(this.container);
-            break;
-          case PanelPosition.CENTER:
-            Main.panel._centerBox.remove_child(this.container);
-            break;
-          case PanelPosition.RIGHT:
-            Main.panel._rightBox.remove_child(this.container);
-            break;
-        }
-
-        switch (new_pos) {
-          case PanelPosition.LEFT:
-            Main.panel._leftBox.add_child(ref);
-            break;
-          case PanelPosition.CENTER:
-            Main.panel._centerBox.add_child(ref);
-            break;
-          case PanelPosition.RIGHT:
-            Main.panel._rightBox.insert_child_at_index(ref, 0);
-        }
-    }
-
-    _on_open_state_changed(state) {
-        if (state) return Clutter.EVENT_PROPAGATE;
-
-        this.context_menu.actor.hide();
-        this.unicon_panel_item.actor.remove_style_pseudo_class('checked');
-        this.unicon_panel_item.actor.remove_style_pseudo_class('focus');
-        this.unicon_panel_item.actor.can_focus = true;
-
-        for (let [, section] of this.sections) {
-            section.panel_item.actor.remove_style_pseudo_class('checked');
-            section.panel_item.actor.remove_style_pseudo_class('focus');
-            section.panel_item.actor.can_focus = true;
-
-            if (section.actor.visible) {
-                section.on_section_open_state_changed(false);
-                section.actor.visible = false;
-            }
-        }
-    }
-
-    _on_theme_changed() {
-        if (this.custom_stylesheet) this._unload_stylesheet();
-        this._load_stylesheet();
-    }
-
-    _load_stylesheet() {
-        this.theme_change_signal_block = true;
-
-        // determine custom stylesheet
-        {
-            let stylesheet = Main.getThemeStylesheet();
-            let path       = stylesheet ? stylesheet.get_path() : '';
-            let theme_dir  = path ? GLib.path_get_dirname(path) : '';
-
-            if (theme_dir) {
-                this.custom_stylesheet =
-                    Gio.file_new_for_path(theme_dir + '/timepp.css');
+                if (section.panel_item.actor.visible) {
+                    section.panel_item.actor.add_style_pseudo_class('checked');
+                    section.panel_item.actor.can_focus = false;
+                }
             }
 
-            if (!this.custom_stylesheet ||
-                !this.custom_stylesheet.query_exists(null)) {
+            this._update_menu_min_size();
+            this._update_separators();
+            this.menu.open();
+        }
 
-                this.custom_stylesheet =
-                    Gio.File.new_for_path(ME.path + '/stylesheet.css');
+        // PanelMenu only updates the min-height, we also need to update min-width.
+        _update_menu_min_size() {
+            let work_area    = Main.layoutManager.getWorkAreaForMonitor(Main.layoutManager.findIndexForActor(this.menu.actor));
+            let monitor      = Main.layoutManager.findMonitorForActor(this.menu.actor);
+            let scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+
+            // @HACK
+            // Some extensions enable autohiding of the panel and as a result the
+            // height of the panel is not taken into account when computing the
+            // work area. This is just a simple work around.
+            let tweak = 16;
+            if (monitor.height === work_area.height)
+                tweak = Main.layoutManager.panelBox.height + tweak;
+
+            let max_h = Math.floor((work_area.height - tweak) / scale_factor);
+            let max_w = Math.floor((work_area.width  - 16) / scale_factor);
+
+            this.menu_max_w = max_w;
+            this.menu_max_h = max_h;
+
+            this.menu.actor.style = `max-height: ${max_h}px; max-width: ${max_w}px;`;
+        }
+
+        _update_menu_arrow(source_actor) {
+            this.menu._boxPointer.setPosition(source_actor, this.menu._arrowAlignment);
+            this.menu.sourceActor = source_actor;
+        }
+
+        _update_separators() {
+            let last_visible;
+
+            for (let [k, sep] of this.separators) {
+                if (this.sections.get(k).actor.visible) {
+                    last_visible = sep;
+                    sep.show();
+                } else {
+                    sep.hide();
+                }
+            }
+
+            if (last_visible) last_visible.hide();
+        }
+
+        _update_custom_css() {
+            let update_needed = false;
+            let theme_node    = this.panel_item_box.get_theme_node();
+
+            for (let prop in this.custom_css) {
+                if (! this.custom_css.hasOwnProperty(prop)) continue;
+
+                let [success, col] = theme_node.lookup_color(prop, false);
+                let hex            = col.to_string();
+
+                if (success && this.custom_css[prop][0] !== hex) {
+                    update_needed = true;
+
+                    this.custom_css[prop] = [hex, [
+                        col.red   / 255,
+                        col.green / 255,
+                        col.blue  / 255,
+                        col.alpha / 255,
+                    ]];
+                }
+            }
+
+            //if (update_needed) this.emit('custom-css-changed');
+        }
+
+        update_panel_items() {
+            if (this.settings.get_boolean('unicon-mode')) {
+                let show_unicon = false;
+
+                for (let [, section] of this.sections) {
+                    if (section.separate_menu) {
+                        section.panel_item.actor.show();
+                    } else {
+                        section.panel_item.actor.hide();
+                        show_unicon = true;
+                    }
+                }
+
+                this.unicon_panel_item.actor.visible = show_unicon;
+            } else {
+                this.unicon_panel_item.actor.hide();
+
+                for (let [, section] of this.sections) {
+                    section.panel_item.actor.visible = true;
+                }
             }
         }
 
-        St.ThemeContext.get_for_stage(global.stage).get_theme().load_stylesheet(this.custom_stylesheet);
+        _on_panel_position_changed(old_pos, new_pos) {
+            let ref = this.container;
 
-        // reload theme
-        Main.reloadThemeResource();
-        Main.loadTheme();
+            switch (old_pos) {
+            case PanelPosition.LEFT:
+                Main.panel._leftBox.remove_child(this.container);
+                break;
+            case PanelPosition.CENTER:
+                Main.panel._centerBox.remove_child(this.container);
+                break;
+            case PanelPosition.RIGHT:
+                Main.panel._rightBox.remove_child(this.container);
+                break;
+            }
 
-        Mainloop.idle_add(() => this.theme_change_signal_block = false);
+            switch (new_pos) {
+            case PanelPosition.LEFT:
+                Main.panel._leftBox.add_child(ref);
+                break;
+            case PanelPosition.CENTER:
+                Main.panel._centerBox.add_child(ref);
+                break;
+            case PanelPosition.RIGHT:
+                Main.panel._rightBox.insert_child_at_index(ref, 0);
+            }
+        }
+
+        _on_open_state_changed(state) {
+            if (state) return Clutter.EVENT_PROPAGATE;
+
+            this.context_menu.actor.hide();
+            this.unicon_panel_item.actor.remove_style_pseudo_class('checked');
+            this.unicon_panel_item.actor.remove_style_pseudo_class('focus');
+            this.unicon_panel_item.actor.can_focus = true;
+
+            for (let [, section] of this.sections) {
+                section.panel_item.actor.remove_style_pseudo_class('checked');
+                section.panel_item.actor.remove_style_pseudo_class('focus');
+                section.panel_item.actor.can_focus = true;
+
+                if (section.actor.visible) {
+                    section.on_section_open_state_changed(false);
+                    section.actor.visible = false;
+                }
+            }
+        }
+
+        _on_theme_changed() {
+            if (this.custom_stylesheet) this._unload_stylesheet();
+            this._load_stylesheet();
+        }
+
+        _load_stylesheet() {
+            this.theme_change_signal_block = true;
+
+            // determine custom stylesheet
+            {
+                let stylesheet = Main.getThemeStylesheet();
+                let path       = stylesheet ? stylesheet.get_path() : '';
+                let theme_dir  = path ? GLib.path_get_dirname(path) : '';
+
+                if (theme_dir) {
+                    this.custom_stylesheet =
+                        Gio.file_new_for_path(theme_dir + '/timepp.css');
+                }
+
+                if (!this.custom_stylesheet ||
+                    !this.custom_stylesheet.query_exists(null)) {
+
+                    this.custom_stylesheet =
+                        Gio.File.new_for_path(ME.path + '/stylesheet.css');
+                }
+            }
+
+            St.ThemeContext.get_for_stage(global.stage).get_theme().load_stylesheet(this.custom_stylesheet);
+
+            // reload theme
+            Main.reloadThemeResource();
+            Main.loadTheme();
+
+            Mainloop.idle_add(() => this.theme_change_signal_block = false);
+        }
+
+        _unload_stylesheet() {
+
+            if (! this.custom_stylesheet) return;
+
+            St.ThemeContext.get_for_stage(global.stage).get_theme()
+                .unload_stylesheet(this.custom_stylesheet);
+
+            this.custom_stylesheet = null;
+        }
+
+        is_section_enabled(section_name) {
+            return this.sections.has(section_name);
+        }
+
+        // Used by sections to communicate with each other.
+        // This way any section can listen for signals on the main ext object.
+        emit_to_sections(sig, section_name, data) {
+            this.emit(sig, {section_name, data});
+        }
+
+        // ScrollView always allocates horizontal space for the scrollbar when the
+        // policy is set to AUTOMATIC. The result is an ugly padding on the right
+        // when the scrollbar is invisible.
+        needs_scrollbar() {
+            let [, nat_h] = this.menu.actor.get_preferred_height(-1);
+            let max_h     = this.menu.actor.get_theme_node().get_max_height();
+
+            return max_h >= 0 && nat_h >= max_h;
+        }
+
+        destroy() {
+            // We need to make sure that this one is set to the default actor or
+            // else the shell will try to destroy the wrong panel actor.
+            this._update_menu_arrow(this.actor);
+
+            for (let [, section] of this.sections) section.disable_section();
+
+            this.sections.clear();
+            this.separators.clear();
+
+            this._unload_stylesheet();
+            this.sigm.clear();
+
+            super.destroy();
+        }
     }
-
-    _unload_stylesheet() {
-
-        if (! this.custom_stylesheet) return;
-
-        St.ThemeContext.get_for_stage(global.stage).get_theme()
-            .unload_stylesheet(this.custom_stylesheet);
-
-        this.custom_stylesheet = null;
-    }
-
-    is_section_enabled(section_name) {
-        return this.sections.has(section_name);
-    }
-
-    // Used by sections to communicate with each other.
-    // This way any section can listen for signals on the main ext object.
-    emit_to_sections(sig, section_name, data) {
-        this.emit(sig, {section_name, data});
-    }
-
-    // ScrollView always allocates horizontal space for the scrollbar when the
-    // policy is set to AUTOMATIC. The result is an ugly padding on the right
-    // when the scrollbar is invisible.
-    needs_scrollbar() {
-        let [, nat_h] = this.menu.actor.get_preferred_height(-1);
-        let max_h     = this.menu.actor.get_theme_node().get_max_height();
-
-        return max_h >= 0 && nat_h >= max_h;
-    }
-
-    destroy() {
-        // We need to make sure that this one is set to the default actor or
-        // else the shell will try to destroy the wrong panel actor.
-        this._update_menu_arrow(this.actor);
-
-        for (let [, section] of this.sections) section.disable_section();
-
-        this.sections.clear();
-        this.separators.clear();
-
-        this._unload_stylesheet();
-        this.sigm.clear();
-
-        super.destroy();
-    }
-}
+)
 
 
 

--- a/lib/date_picker.js
+++ b/lib/date_picker.js
@@ -1,8 +1,9 @@
 const St      = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 const Main    = imports.ui.main;
-const Lang    = imports.lang;
 const Signals = imports.signals;
+const GObject    = imports.gi.GObject
+
 
 
 // =====================================================================
@@ -18,10 +19,9 @@ const Signals = imports.signals;
 //       @date_arr: array  (of ints [year, month, day]. Month is 0-indexed)
 //       @date_str: string (in yyyy-mm-dd format)
 // =====================================================================
-var DatePicker = new Lang.Class({
-    Name: 'Timepp.DatePicker',
+class DatePicker{
 
-    _init: function (lower_bound_str, upper_bound_str, labels, do_wrap) {
+    constructor(lower_bound_str, upper_bound_str, labels, do_wrap) {
         this.lower_bound_str = lower_bound_str;
         this.upper_bound_str = upper_bound_str;
         this.do_wrap         = do_wrap;
@@ -70,29 +70,29 @@ var DatePicker = new Lang.Class({
         this.day_picker.connect('changed',   (_, direction) => {
             this._on_date_changed('d', direction);
         });
-    },
+    }
 
     // @date: string (in iso yyyy-mm-dd format)
-    set_date_from_string: function (date) {
+    set_date_from_string(date) {
         this.date.setFullYear(+(date.substr(0, 4)));
         this.date.setMonth(+(date.substr(5, 2) - 1));
         this.date.setDate(+(date.substr(8, 2)));
 
         this._update_pickers();
-    },
+    }
 
     // @year  : int
     // @month : int (0-indexed)
     // @day   : int
-    set_date: function (year, month, day) {
+    set_date(year, month, day) {
         this.date.setFullYear(year);
         this.date.setMonth(month);
         this.date.setDate(day);
 
         this._update_pickers();
-    },
+    }
 
-    get_date: function () {
+    get_date() {
         let date = [
             this.date.getFullYear(),
             this.date.getMonth(),
@@ -102,15 +102,15 @@ var DatePicker = new Lang.Class({
         let date_str = '%d-%02d-%02d'.format(date[0], date[1] + 1, date[2]);
 
         return [date, date_str];
-    },
+    }
 
-    get_range: function () {
+    get_range() {
         return [this.lower_bound_str, this.upper_bound_str];
-    },
+    }
 
     // @lower_bound_str : string (in iso yyyy-mm-dd format)
     // @upper_bound_str : string (in iso yyyy-mm-dd format)
-    set_range: function (lower_bound_str, upper_bound_str) {
+    set_range(lower_bound_str, upper_bound_str) {
         this.lower_bound_str = lower_bound_str;
         this.upper_bound_str = upper_bound_str;
         this.lower_bound     = null;
@@ -131,17 +131,17 @@ var DatePicker = new Lang.Class({
                 +(upper_bound_str.substr(8, 2)),
             ];
         }
-    },
+    }
 
-    _update_pickers: function () {
+    _update_pickers() {
         this.year_picker.counter.text  = '' + this.date.getFullYear();
         this.month_picker.counter.text = '%02d'.format(this.date.getMonth() + 1);
         this.day_picker.counter.text   = '%02d'.format(this.date.getDate());
-    },
+    }
 
     // @ymd       : one of ['y', 'm', 'd'] (1=year, 2=month, 3=day)
     // @direction : one of [1, -1]         (increment or decrement)
-    _on_date_changed: function (ymd, direction) {
+    _on_date_changed(ymd, direction) {
         let prev_date = [
             this.date.getFullYear(),
             this.date.getMonth(),
@@ -201,8 +201,8 @@ var DatePicker = new Lang.Class({
         this.date.setDate(new_date[2]);
 
         this._update_pickers();
-    },
-});
+    }
+}
 Signals.addSignalMethods(DatePicker.prototype);
 
 
@@ -214,10 +214,9 @@ Signals.addSignalMethods(DatePicker.prototype);
 //
 // @signals: 'changed' (returns 1 or -1)
 // =====================================================================
-const DatePickerItem = new Lang.Class({
-    Name: 'Timepp.DatePickerItem',
+class DatePickerItem {
 
-    _init: function (label) {
+    constructor(label) {
         this.actor = new St.BoxLayout({ reactive: true, style_class: 'date-picker-item' });
 
 
@@ -277,9 +276,9 @@ const DatePickerItem = new Lang.Class({
                 break;
             }
         });
-    },
+    }
 
-    _on_press_event: function (event, increment) {
+    _on_press_event(event, increment) {
         if (event.type() === Clutter.EventType.BUTTON_PRESS &&
             event.get_button() === Clutter.BUTTON_PRIMARY) {
 
@@ -291,6 +290,6 @@ const DatePickerItem = new Lang.Class({
             if (key_id === Clutter.KEY_space || key_id === Clutter.KEY_Return)
                 this.emit('changed', increment);
         }
-    },
-});
+    }
+}
 Signals.addSignalMethods(DatePickerItem.prototype);

--- a/lib/date_picker.js
+++ b/lib/date_picker.js
@@ -19,7 +19,7 @@ const GObject    = imports.gi.GObject
 //       @date_arr: array  (of ints [year, month, day]. Month is 0-indexed)
 //       @date_str: string (in yyyy-mm-dd format)
 // =====================================================================
-class DatePicker{
+var DatePicker = class DatePicker{
 
     constructor(lower_bound_str, upper_bound_str, labels, do_wrap) {
         this.lower_bound_str = lower_bound_str;
@@ -214,7 +214,7 @@ Signals.addSignalMethods(DatePicker.prototype);
 //
 // @signals: 'changed' (returns 1 or -1)
 // =====================================================================
-class DatePickerItem {
+var DatePickerItem  = class DatePickerItem {
 
     constructor(label) {
         this.actor = new St.BoxLayout({ reactive: true, style_class: 'date-picker-item' });

--- a/lib/date_picker.js
+++ b/lib/date_picker.js
@@ -4,6 +4,8 @@ const Main    = imports.ui.main;
 const Signals = imports.signals;
 const GObject    = imports.gi.GObject
 
+const ME = imports.misc.extensionUtils.getCurrentExtension();
+const MISC_UTILS      = ME.imports.lib.misc_utils;
 
 
 // =====================================================================
@@ -244,11 +246,11 @@ var DatePickerItem  = class DatePickerItem {
 
         this.btn_up = new St.Button({ can_focus: true, style_class: 'arrow-btn' });
         arrow_box.add_actor(this.btn_up);
-        this.btn_up.add_actor(new St.Icon({ icon_name: 'timepp-pan-up-symbolic' }));
+        this.btn_up.add_actor(new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-pan-up-symbolic') }));
 
         this.btn_down = new St.Button({ can_focus: true, style_class: 'arrow-btn' });
         arrow_box.add_actor(this.btn_down);
-        this.btn_down.add_actor(new St.Icon({ icon_name: 'timepp-pan-down-symbolic' }));
+        this.btn_down.add_actor(new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-pan-down-symbolic') }));
 
 
         //

--- a/lib/day_chooser.js
+++ b/lib/day_chooser.js
@@ -11,10 +11,9 @@ const MSECS_IN_DAY = 86400000;
 //
 // @checked: bool (true = all days selected, false = no days selected)
 // =====================================================================
-var DayChooser = new Lang.Class({
-    Name: 'Timepp.DayChooser',
+class DayChooser{
 
-    _init: function (checked) {
+    constructor(checked) {
         this.actor = new St.BoxLayout({ reactive: true, style_class: 'row days' });
 
         let week_start = Shell.util_get_week_start();
@@ -48,10 +47,10 @@ var DayChooser = new Lang.Class({
                 else             btn.remove_style_pseudo_class('active');
             });
         }
-    },
+    }
 
     // Returns array of ints of all days that are selected/checked. Sunday is 0.
-    get_days: function () {
+    get_days() {
         let res = [];
 
         this.buttons.forEach((b, i) => {
@@ -59,5 +58,5 @@ var DayChooser = new Lang.Class({
         });
 
         return res;
-    },
-});
+    }
+}

--- a/lib/day_chooser.js
+++ b/lib/day_chooser.js
@@ -1,7 +1,7 @@
 const St      = imports.gi.St;
 const Shell   = imports.gi.Shell;
 const Clutter = imports.gi.Clutter;
-const Lang    = imports.lang;
+
 
 const MSECS_IN_DAY = 86400000;
 

--- a/lib/day_chooser.js
+++ b/lib/day_chooser.js
@@ -11,7 +11,7 @@ const MSECS_IN_DAY = 86400000;
 //
 // @checked: bool (true = all days selected, false = no days selected)
 // =====================================================================
-class DayChooser{
+var DayChooser = class DayChooser{
 
     constructor(checked) {
         this.actor = new St.BoxLayout({ reactive: true, style_class: 'row days' });

--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -60,7 +60,7 @@ let scrollbar_init_grab_coord = null // null or [x, y]
 // This class makes this possible with the 'this.drag_enabled' prop. But make
 // sure that you set this prop on the dnd instance of every draggable item.
 // =====================================================================
-class Draggable{
+var Draggable = class Draggable{
 
     constructor(item, dnd_group, vertical = true) {
         this.item      = item;

--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -60,12 +60,11 @@ let scrollbar_init_grab_coord = null // null or [x, y]
 // This class makes this possible with the 'this.drag_enabled' prop. But make
 // sure that you set this prop on the dnd instance of every draggable item.
 // =====================================================================
-var Draggable = new Lang.Class({
-    Name: 'Timepp.Draggable',
+class Draggable{
 
-    _init: function (item, dnd_group = "", vertical = true) {
+    constructor(item, dnd_group, vertical = true) {
         this.item      = item;
-        this.dnd_group = dnd_group;
+        this.dnd_group = dnd_group || ""
         this.vertical  = vertical;
 
         item.actor._delegate = this;
@@ -89,9 +88,9 @@ var Draggable = new Lang.Class({
                 return orig.call(this.dnd, event);
             }
         }
-    },
+    }
 
-    _on_item_dropped: function () {
+    _on_item_dropped() {
         // @HACK
         // We need to reset this manually or else the maybeStartDrag func will
         // never be called.
@@ -119,9 +118,9 @@ var Draggable = new Lang.Class({
             this.item.owner.on_drag_end(this.original_parent, this.item.actor_parent, this.item);
 
         this.original_parent = null;
-    },
+    }
 
-    _on_drag_motion: function (drag_event) {
+    _on_drag_motion(drag_event) {
         if (!this.drag_enabled || drag_event.source !== this) return DND.DragMotionResult.CONTINUE;
 
         let t = drag_event.targetActor;
@@ -212,9 +211,9 @@ var Draggable = new Lang.Class({
         if (! found) this._stop_scroll_loop();
 
         return res;
-    },
+    }
 
-    getDragActor: function () {
+    getDragActor() {
         // If this function fails for some reason, it'll cause a nasty deadlock
         // that will require a shell restart.
         try {
@@ -262,9 +261,9 @@ var Draggable = new Lang.Class({
             this.drag_monitor = null;
             return new St.Bin();
         }
-    },
+    }
 
-    handleDragOver: function (source, drag_actor, x, y, time) {
+    handleDragOver(source, drag_actor, x, y, time) {
         if (!this.drag_enabled)                  return DND.DragMotionResult.CONTINUE;
         if (source.item === this.item)           return DND.DragMotionResult.MOVE_DROP;
         if (source.dnd_group !== this.dnd_group) return DND.DragMotionResult.CONTINUE;
@@ -282,9 +281,9 @@ var Draggable = new Lang.Class({
         }
 
         return DND.DragMotionResult.MOVE_DROP;
-    },
+    }
 
-    _set_above: function (first, second) {
+    _set_above(first, second) {
         if (second.actor.get_next_sibling() === first.actor) return;
 
         if (first.actor_parent === second.actor_parent) {
@@ -294,9 +293,9 @@ var Draggable = new Lang.Class({
             first.actor_parent = second.actor_parent;
             first.actor_parent.insert_child_above(first.actor, second.actor);
         }
-    },
+    }
 
-    _set_below: function (first, second) {
+    _set_below(first, second) {
         if (second.actor.get_previous_sibling() === first.actor) return;
 
         if (first.actor_parent === second.actor_parent) {
@@ -306,20 +305,20 @@ var Draggable = new Lang.Class({
             first.actor_parent = second.actor_parent;
             first.actor_parent.insert_child_below(first.actor, second.actor);
         }
-    },
+    }
 
-    _start_scroll_loop: function (scrollview, direction) {
+    _start_scroll_loop(scrollview, direction) {
         this._stop_scroll_loop();
         this._scroll(scrollview, direction);
-    },
+    }
 
-    _stop_scroll_loop: function () {
+    _stop_scroll_loop() {
         if (!scroll_loop_id) return;
         Mainloop.source_remove(scroll_loop_id);
         scroll_loop_id = null;
-    },
+    }
 
-    _scroll: function (scrollview, direction) {
+    _scroll(scrollview, direction) {
         let vbar = direction ? scrollview.get_hscroll_bar() : scrollview.get_vscroll_bar();
         if (!vbar) return;
 
@@ -327,5 +326,5 @@ var Draggable = new Lang.Class({
         a.set_value(20 * scroll_direction + a.get_value());
 
         scroll_loop_id = Mainloop.timeout_add(scroll_speed, () => this._scroll(scrollview, direction));
-    },
-});
+    }
+}

--- a/lib/dnd.js
+++ b/lib/dnd.js
@@ -4,7 +4,7 @@ const Shell    = imports.gi.Shell;
 const Main     = imports.ui.main;
 const Clutter  = imports.gi.Clutter;
 const DND      = imports.ui.dnd;
-const Lang     = imports.lang;
+
 const Mainloop = imports.mainloop;
 
 

--- a/lib/fullscreen.js
+++ b/lib/fullscreen.js
@@ -22,7 +22,7 @@ const MISC = ME.imports.lib.misc_utils;
 //
 // signals: 'monitor-changed', 'closed', 'opened'
 // =====================================================================
-class Fullscreen{
+var Fullscreen = class Fullscreen{
 
     constructor(monitor) {
         this.is_open                        = false;

--- a/lib/fullscreen.js
+++ b/lib/fullscreen.js
@@ -22,10 +22,9 @@ const MISC = ME.imports.lib.misc_utils;
 //
 // signals: 'monitor-changed', 'closed', 'opened'
 // =====================================================================
-var Fullscreen = new Lang.Class({
-    Name: 'Timepp.Fullscreen',
+class Fullscreen{
 
-    _init: function (monitor) {
+    constructor(monitor) {
         this.is_open                        = false;
         this.monitor                        = monitor;
         this.prev_banner_length             = 0;
@@ -155,9 +154,9 @@ var Fullscreen = new Lang.Class({
                 this.actor.navigate_focus(global.stage.get_key_focus(), direction, true);
             }
         });
-    },
+    }
 
-    destroy: function () {
+    destroy() {
         if (this.monitor_change_id) {
             Main.layoutManager.disconnect(this.monitor_change_id);
             this.monitor_change_id = null;
@@ -170,9 +169,9 @@ var Fullscreen = new Lang.Class({
 
         this.monitors_menu.destroy();
         this.actor.destroy();
-    },
+    }
 
-    close: function () {
+    close() {
         if (! this.is_open) return;
 
         this.is_open = false;
@@ -180,9 +179,9 @@ var Fullscreen = new Lang.Class({
         Main.layoutManager.removeChrome(this.actor);
 
         this.emit('closed');
-    },
+    }
 
-    open: function () {
+    open() {
         if (this.is_open) {
             this.actor.grab_key_focus();
             this.actor.raise_top();
@@ -198,9 +197,9 @@ var Fullscreen = new Lang.Class({
         if (this.banner_size_update_needed) this._update_banner_size();
 
         this.emit('opened');
-    },
+    }
 
-    _update_monitor_position: function (n) {
+    _update_monitor_position(n) {
         if (n < this.display.get_n_monitors()) {
             this.monitor_constraint.index = n;
             this.monitor = n;
@@ -208,9 +207,9 @@ var Fullscreen = new Lang.Class({
         } else {
             this.monitor_constraint.index = this.display.get_current_monitor();
         }
-    },
+    }
 
-    _update_monitors_menu: function () {
+    _update_monitors_menu() {
         let n_monitors = this.display.get_n_monitors();
         let primary_monitor = this.display.get_primary_monitor();
 
@@ -238,9 +237,9 @@ var Fullscreen = new Lang.Class({
                 this._update_monitor_position(i);
             });
         }
-    },
+    }
 
-    set_banner_text: function (markup) {
+    set_banner_text(markup) {
         this.banner_markup = markup;
 
         // Since the banner is a monospaced font, we only need to recompute the
@@ -252,10 +251,10 @@ var Fullscreen = new Lang.Class({
         }
 
         this.prev_banner_length = markup.length;
-    },
+    }
 
     // @perc: num [0, 1] (percentage of width the text will occupy)
-    set_banner_size: function (perc) {
+    set_banner_size(perc) {
         perc = Math.min(Math.max(perc, 0), 1);
 
         if (this.banner_size === perc) return;
@@ -263,9 +262,9 @@ var Fullscreen = new Lang.Class({
         this.banner_size = perc;
         this.banner_size_update_needed = true;
         this._update_banner_size();
-    },
+    }
 
-    _update_banner_size: function () {
+    _update_banner_size() {
         if (!this.is_open) return;
 
         this.banner_size_update_needed = false;
@@ -286,9 +285,9 @@ var Fullscreen = new Lang.Class({
         this.banner_container.style = `padding: 0 ${border_width}px;`;
 
         this._fit_banner();
-    },
+    }
 
-    _fit_banner: function (caller) {
+    _fit_banner(caller) {
         this.banner_container_handler_block = true;
 
         let container = this.banner_container;
@@ -374,6 +373,6 @@ var Fullscreen = new Lang.Class({
         }
 
         this.banner_container_handler_block = false;
-    },
-});
+    }
+}
 Signals.addSignalMethods(Fullscreen.prototype);

--- a/lib/fullscreen.js
+++ b/lib/fullscreen.js
@@ -72,7 +72,7 @@ var Fullscreen = class Fullscreen{
         // monitor button/popup
         this.monitor_button = new St.Button({ reactive: true, can_focus: true, style_class: 'monitor-icon' });
         this.top_box_left.add_actor(this.monitor_button);
-        let monitor_icon = new St.Icon({ icon_name: 'timepp-monitor-symbolic' });
+        let monitor_icon = new St.Icon({ gicon : MISC.getIcon('timepp-monitor-symbolic') });
         this.monitor_button.add_actor(monitor_icon);
 
         this.monitors_menu = new PopupMenu.PopupMenu(this.monitor_button, 0.5, St.Side.TOP);
@@ -84,7 +84,7 @@ var Fullscreen = class Fullscreen{
         // close button
         this.close_button = new St.Button({ can_focus: true, style_class: 'close-icon' });
         this.top_box_right.add_actor(this.close_button);
-        let close_icon = new St.Icon({ icon_name: 'timepp-close-symbolic' });
+        let close_icon = new St.Icon({ gicon : MISC.getIcon('timepp-close-symbolic') });
         this.close_button.add_actor(close_icon);
 
 

--- a/lib/fullscreen.js
+++ b/lib/fullscreen.js
@@ -5,7 +5,7 @@ const Clutter   = imports.gi.Clutter;
 const Main      = imports.ui.main;
 const Layout    = imports.ui.layout;
 const PopupMenu = imports.ui.popupMenu;
-const Lang      = imports.lang;
+
 const Signals   = imports.signals;
 
 

--- a/lib/graphs.js
+++ b/lib/graphs.js
@@ -5,7 +5,7 @@ const Meta       = imports.gi.Meta;
 const Clutter    = imports.gi.Clutter;
 const Pango      = imports.gi.Pango;
 const PangoCairo = imports.gi.PangoCairo;
-const Lang       = imports.lang;
+
 const Signals    = imports.signals;
 const Mainloop   = imports.mainloop;
 

--- a/lib/graphs.js
+++ b/lib/graphs.js
@@ -29,7 +29,7 @@ const MISC = ME.imports.lib.misc_utils;
 // @signals:
 //   - 'vbar-clicked' (returns label of clicked vbar)
 // =====================================================================
-class VBars {
+var VBars  = class VBars {
     
 
     constructor() {
@@ -501,7 +501,7 @@ Signals.addSignalMethods(VBars.prototype);
 // @signals:
 //   - 'square-clicked' (returns label of clicked square);
 // =====================================================================
-class HeatMap {
+var HeatMap  = class HeatMap {
     
 
     constructor() {

--- a/lib/graphs.js
+++ b/lib/graphs.js
@@ -29,10 +29,10 @@ const MISC = ME.imports.lib.misc_utils;
 // @signals:
 //   - 'vbar-clicked' (returns label of clicked vbar)
 // =====================================================================
-var VBars = new Lang.Class({
-    Name: 'Timepp.VBars',
+class VBars {
+    
 
-    _init: function () {
+    constructor() {
         // @this.vbars: array of @vbar
         //
         // @vbar: obj of form:
@@ -181,13 +181,13 @@ var VBars = new Lang.Class({
         this.vbars_drawing_area.connect('button-press-event', () => {
             if (this.selected_vbar) this.emit('vbar-clicked', ...this.selected_vbar);
         });
-    },
+    }
 
     // @params: obj
     //   - An object containing properties that are going to replace
     //     the ones from the this.coord_info obj.
     //     Properties that have been omitted will use default values.
-    draw_coord_system: function (params) {
+    draw_coord_system(params) {
         for (let prop in params) {
             if (!params.hasOwnProperty(prop) || !this.coord_info.hasOwnProperty(prop))
                 continue;
@@ -196,14 +196,14 @@ var VBars = new Lang.Class({
         }
 
         this.coord_system_drawing_area.queue_repaint();
-    },
+    }
 
     // @vbars : array (for description, see comment of this.vbars array.)
     // @min_w : int   (min width of vbars.)
     // @min_w : int   (max width of vbars.)
     // @tooltip_format_callback: func (optional)
     //   (for description, see comment of this.tooltip_format_callback() func.)
-    draw_vbars: function (vbars, min_w, max_w, tooltip_format_callback) {
+    draw_vbars(vbars, min_w, max_w, tooltip_format_callback) {
         this.vbars = vbars;
 
         this.vbars_min_width = min_w;
@@ -213,11 +213,11 @@ var VBars = new Lang.Class({
             this.tooltip_format_callback = tooltip_format_callback;
 
         this.vbars_drawing_area.queue_repaint();
-    },
+    }
 
     // This func should never be called directly, only as a signal handler
     // of the 'repaint' signal.
-    _draw_coord_system: function (area) {
+    _draw_coord_system(area) {
         let cr   = area.get_context();
         let coor = this.coord_info;
 
@@ -283,11 +283,11 @@ var VBars = new Lang.Class({
         }
 
         cr.$dispose();
-    },
+    }
 
     // This func should never be called directly, only as a signal handler
     // of the 'repaint' signal.
-    _draw_vbars: function (area) {
+    _draw_vbars(area) {
         this.graph_scroll_view.hscrollbar_policy = Gtk.PolicyType.NEVER;
 
         this.vbars_pos = [];
@@ -398,9 +398,9 @@ var VBars = new Lang.Class({
         area.set_width(texture_w);
 
         cr.$dispose();
-    },
+    }
 
-    _on_graph_scrolled: function (direction) {
+    _on_graph_scrolled(direction) {
         let delta = 0;
 
         switch (direction) {
@@ -418,9 +418,9 @@ var VBars = new Lang.Class({
             delta * this.graph_scroll_view.hscroll.adjustment.stepIncrement;
 
         return Clutter.EVENT_STOP;
-    },
+    }
 
-    _find_selected_bar: function (event) {
+    _find_selected_bar(event) {
         // get screen coord of mouse
         let [x, y] = event.get_coords();
 
@@ -486,8 +486,8 @@ var VBars = new Lang.Class({
         }
 
         this.selected_vbar = found;
-    },
-});
+    }
+}
 Signals.addSignalMethods(VBars.prototype);
 
 
@@ -501,10 +501,10 @@ Signals.addSignalMethods(VBars.prototype);
 // @signals:
 //   - 'square-clicked' (returns label of clicked square);
 // =====================================================================
-var HeatMap = new Lang.Class({
-    Name: 'Timepp.HeatMap',
+class HeatMap {
+    
 
-    _init: function () {
+    constructor() {
         // @matrix: array of arrays (2d matrix of 0 or objects of form:
         //     {
         //         label : string,
@@ -606,20 +606,20 @@ var HeatMap = new Lang.Class({
         this.heatmap_drawing_area.connect('button-press-event', () => {
             if (this.hovered_square) this._on_square_clicked();
         });
-    },
+    }
 
     // @params: obj (props with which to update the this.params obj)
-    update_params: function (params) {
+    update_params(params) {
         if (params) {
             for (let p in params) {
                 if (params.hasOwnProperty(p) && this.params.hasOwnProperty(p))
                     this.params[p] = params[p];
             }
         }
-    },
+    }
 
     // @params: obj (props with which to update the this.params obj)
-    draw_heatmap: function (params) {
+    draw_heatmap(params) {
         this.update_params(params);
 
         let s = this.params.square_size + this.params.square_spacing;
@@ -630,11 +630,11 @@ var HeatMap = new Lang.Class({
         );
 
         this.heatmap_drawing_area.queue_repaint();
-    },
+    }
 
     // This func should never be called directly, only as a signal handler
     // of the 'repaint' signal.
-    _draw_heatmap: function (area) {
+    _draw_heatmap(area) {
         let cr = area.get_context();
 
         let square_size        = this.params.square_size;
@@ -704,9 +704,9 @@ var HeatMap = new Lang.Class({
         }
 
         cr.$dispose();
-    },
+    }
 
-    _on_graph_scrolled: function (direction) {
+    _on_graph_scrolled(direction) {
         let delta = 0;
 
         switch (direction) {
@@ -724,17 +724,17 @@ var HeatMap = new Lang.Class({
             delta * this.graph_scroll_view.hscroll.adjustment.stepIncrement;
 
         return Clutter.EVENT_STOP;
-    },
+    }
 
-    _on_square_clicked: function () {
+    _on_square_clicked() {
         this.selected_square     = this.hovered_square;
         this.selected_square_pos = this.hovered_square_pos;
         this.draw_heatmap();
 
         this.emit('square-clicked', this.hovered_square.label);
-    },
+    }
 
-    _find_selected_square: function (event) {
+    _find_selected_square(event) {
         // get screen coord of mouse
         let [x, y] = event.get_coords();
 
@@ -798,6 +798,6 @@ var HeatMap = new Lang.Class({
             this.heatmap_tooltip.set_position(tooltip_x - h_scroll, tooltip_y);
             this.heatmap_tooltip.raise_top();
         }
-    },
-});
+    }
+}
 Signals.addSignalMethods(HeatMap.prototype);

--- a/lib/keybinding_manager.js
+++ b/lib/keybinding_manager.js
@@ -15,15 +15,15 @@ const ACTION_MODE = Shell.ActionMode.NORMAL |
 //
 // @settings: the extension settings object
 // =====================================================================
-var KeybindingManager = new Lang.Class({
-    Name: 'Timepp.KeybindingManager',
+class KeybindingManager {
+    
 
-    _init: function (settings) {
+    constructor(settings) {
         this.settings = settings;
         this.key_ids  = new Set();
-    },
+    }
 
-    add: function (id, callback) {
+    add(id, callback) {
         this.key_ids.add(id);
 
         Main.wm.addKeybinding(
@@ -33,10 +33,10 @@ var KeybindingManager = new Lang.Class({
             ACTION_MODE,
             callback
         );
-    },
+    }
 
-    clear: function () {
+    clear() {
         for (let id of this.key_ids) Main.wm.removeKeybinding(id);
         this.key_ids.clear();
-    },
-});
+    }
+}

--- a/lib/keybinding_manager.js
+++ b/lib/keybinding_manager.js
@@ -15,7 +15,7 @@ const ACTION_MODE = Shell.ActionMode.NORMAL |
 //
 // @settings: the extension settings object
 // =====================================================================
-class KeybindingManager {
+var KeybindingManager  = class KeybindingManager {
     
 
     constructor(settings) {

--- a/lib/keybinding_manager.js
+++ b/lib/keybinding_manager.js
@@ -1,6 +1,6 @@
 const Meta  = imports.gi.Meta;
 const Shell = imports.gi.Shell;
-const Lang  = imports.lang;
+
 const Main  = imports.ui.main;
 
 const ACTION_MODE = Shell.ActionMode.NORMAL |

--- a/lib/misc_utils.js
+++ b/lib/misc_utils.js
@@ -455,3 +455,7 @@ function markdown_to_pango (string, markdown_map) {
 
     return res;
 }
+
+function getIcon(name){
+    return Gio.icon_new_for_string(ME.path + '/data/img/icons/' + name + ".svg");
+}

--- a/lib/multiline_entry.js
+++ b/lib/multiline_entry.js
@@ -13,7 +13,7 @@ const Mainloop = imports.mainloop;
 // @scrollable       : bool (make entry use scrollbar or grow indefinitely)
 // @single_line_mode : bool (removes any line breaks, still wraps)
 // =====================================================================
-class MultiLineEntry{
+var MultiLineEntry = class MultiLineEntry{
 
     constructor(hint_text, scrollable, single_line_mode) {
         this.scrollable       = scrollable;

--- a/lib/multiline_entry.js
+++ b/lib/multiline_entry.js
@@ -2,7 +2,7 @@ const St       = imports.gi.St;
 const Meta     = imports.gi.Meta;
 const Pango    = imports.gi.Pango;
 const Clutter  = imports.gi.Clutter;
-const Lang     = imports.lang;
+
 const Mainloop = imports.mainloop;
 
 

--- a/lib/multiline_entry.js
+++ b/lib/multiline_entry.js
@@ -13,10 +13,9 @@ const Mainloop = imports.mainloop;
 // @scrollable       : bool (make entry use scrollbar or grow indefinitely)
 // @single_line_mode : bool (removes any line breaks, still wraps)
 // =====================================================================
-var MultiLineEntry = new Lang.Class({
-    Name: 'Timepp.MultiLineEntry',
+class MultiLineEntry{
 
-    _init: function(hint_text, scrollable, single_line_mode) {
+    constructor(hint_text, scrollable, single_line_mode) {
         this.scrollable       = scrollable;
         this.single_line_mode = single_line_mode;
 
@@ -75,16 +74,16 @@ var MultiLineEntry = new Lang.Class({
         this.entry.connect('key-press-event', (_, event) => {
             return this._maybe_resize_with_keyboard(event);
         });
-    },
+    }
 
-    set_text: function (text) {
+    set_text(text) {
         Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
             this.entry.set_text(text);
             Mainloop.timeout_add(0, () => this._resize_entry());
         });
-    },
+    }
 
-    insert_text: function (text) {
+    insert_text(text) {
         if (this.single_line_mode) return Clutter.EVENT_PROPAGATE;
 
         let pos = this.entry.clutter_text.cursor_position;
@@ -96,17 +95,17 @@ var MultiLineEntry = new Lang.Class({
             let p = pos + text.length;
             this.entry.clutter_text.set_selection(p, p);
         }
-    },
+    }
 
-    _before_text_changed: function (added_text, length_of_added_text) {
+    _before_text_changed(added_text, length_of_added_text) {
         // If the text was pasted in (longer than 1 char) or is a newline, set
         // the sanitize flag to true so that after_text_changed cleans the line
         // breaks.
         if (length_of_added_text > 1 || /\r?\n/g.test(added_text))
             this.sanitize_flag = true;
-    },
+    }
 
-    _after_text_changed: function () {
+    _after_text_changed() {
         if (this.sanitize_flag) {
             let txt = this.entry.get_text();
             this.entry.set_text(txt.replace(/[\r\n]/g, ' '));
@@ -114,9 +113,9 @@ var MultiLineEntry = new Lang.Class({
         }
 
         this._resize_entry();
-    },
+    }
 
-    _maybe_resize_with_keyboard: function (event) {
+    _maybe_resize_with_keyboard(event) {
         if (! this.resize_with_keyboard) return;
         if (event.get_state() !== Clutter.ModifierType.CONTROL_MASK) return;
 
@@ -141,9 +140,9 @@ var MultiLineEntry = new Lang.Class({
         }
 
         return Clutter.EVENT_STOP;
-    },
+    }
 
-    _resize_entry: function () {
+    _resize_entry() {
         let theme_node     = this.entry.get_theme_node();
         let a              = this.entry.get_allocation_box();
         let [, nat_height] = this.entry.clutter_text.get_preferred_height(theme_node.adjust_for_width(a.x2 - a.x1));
@@ -151,5 +150,5 @@ var MultiLineEntry = new Lang.Class({
 
         let entry_h = theme_node.adjust_for_height(a.y2 - a.y1);
         if (this.keep_min_height || entry_h <= h) this.entry.set_height(h);
-    },
-});
+    }
+}

--- a/lib/num_picker.js
+++ b/lib/num_picker.js
@@ -1,6 +1,6 @@
 const St       = imports.gi.St;
 const Clutter  = imports.gi.Clutter;
-const Lang     = imports.lang;
+
 const Signals  = imports.signals;
 
 

--- a/lib/num_picker.js
+++ b/lib/num_picker.js
@@ -15,10 +15,10 @@ const Signals  = imports.signals;
 // @signals:
 //   'spinner-changed' (returns counter value and pointer to counter text actor)
 // =====================================================================
-var NumPicker = new Lang.Class({
-    Name: 'Timepp.NumPicker',
+class NumPicker {
+    
 
-    _init: function(num_min, num_max, num_init) {
+    constructor(num_min, num_max, num_init) {
         this.num_min  = num_min;
         this.num_max  = num_max;
         this.num_init = num_init;
@@ -71,9 +71,9 @@ var NumPicker = new Lang.Class({
         this.btn_down.connect('key-press-event', (actor, event) => this._on_press_event(actor, event, 'down'));
 
         this.actor.connect('scroll-event', (actor, event) => this._on_scroll_event(actor, event));
-    },
+    }
 
-    _on_press_event: function (actor, event, step) {
+    _on_press_event (actor, event, step) {
         if (event.type() === Clutter.EventType.BUTTON_PRESS) {
             let button_id = event.get_button();
 
@@ -86,18 +86,18 @@ var NumPicker = new Lang.Class({
             if (key_id === Clutter.KEY_space || key_id === Clutter.KEY_Return)
                 this._update_counter(step);
         }
-    },
+    }
 
-    _on_scroll_event: function (actor, event) {
+    _on_scroll_event (actor, event) {
         let direction = event.get_scroll_direction();
 
         if (direction == Clutter.ScrollDirection.DOWN)
             this._update_counter('down');
         else if (direction == Clutter.ScrollDirection.UP)
             this._update_counter('up');
-    },
+    }
 
-    _update_counter: function (step) {
+    _update_counter (step) {
         if (step === 'up')   this.counter++;
         if (step === 'down') this.counter--;
 
@@ -121,20 +121,20 @@ var NumPicker = new Lang.Class({
         }
 
         this.emit('spinner-changed', this.counter, this.counter_label);
-    },
+    }
 
-    _left_pad: function (num, size) {
+    _left_pad (num, size) {
         let s = '' + Math.abs(num);
 
         while (s.length < (size || 2)) {s = '0' + s;}
 
         if (num < 0) return '-' + s;
         else         return s;
-    },
+    }
 
-    set_counter: function (num) {
+    set_counter (num) {
         this.counter_label.text = this._left_pad(num, 2);
         this.counter = num;
-    },
-});
+    }
+}
 Signals.addSignalMethods(NumPicker.prototype);

--- a/lib/num_picker.js
+++ b/lib/num_picker.js
@@ -15,7 +15,7 @@ const Signals  = imports.signals;
 // @signals:
 //   'spinner-changed' (returns counter value and pointer to counter text actor)
 // =====================================================================
-class NumPicker {
+var NumPicker  = class NumPicker {
     
 
     constructor(num_min, num_max, num_init) {

--- a/lib/num_picker.js
+++ b/lib/num_picker.js
@@ -3,6 +3,8 @@ const Clutter  = imports.gi.Clutter;
 
 const Signals  = imports.signals;
 
+const ME = imports.misc.extensionUtils.getCurrentExtension();
+const MISC_UTILS      = ME.imports.lib.misc_utils;
 
 // =====================================================================
 // @@@ NumPicker
@@ -55,8 +57,8 @@ var NumPicker  = class NumPicker {
         this.btn_box.add_actor(this.btn_up);
         this.btn_box.add_actor(this.btn_down);
 
-        this.arrow_up   = new St.Icon({ icon_name: 'timepp-pan-up-symbolic' });
-        this.arrow_down = new St.Icon({ icon_name: 'timepp-pan-down-symbolic' });
+        this.arrow_up   = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-pan-up-symbolic') });
+        this.arrow_down = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-pan-down-symbolic') });
         this.btn_up.add_actor(this.arrow_up);
         this.btn_down.add_actor(this.arrow_down);
 

--- a/lib/panel_item.js
+++ b/lib/panel_item.js
@@ -15,10 +15,8 @@ const Signals = imports.signals;
 //     'middle-click'
 //     'right-click'
 // =====================================================================
-var PanelItem = new Lang.Class({
-    Name: 'Timepp.PanelItem',
-
-    _init: function (menu) {
+class PanelItem {
+    constructor (menu) {
         this.menu = menu;
 
         this.mode = 'icon_text'; // one of 'icon', 'text', 'icon_text'
@@ -64,9 +62,9 @@ var PanelItem = new Lang.Class({
                                          true);
             }
         });
-    },
+    }
 
-    set_mode: function (mode) {
+    set_mode (mode) {
         this.mode = mode;
 
         switch (mode) {
@@ -82,12 +80,12 @@ var PanelItem = new Lang.Class({
             this.icon.show();
             this.label.show();
         }
-    },
+    }
 
-    set_label: function (str) {
+    set_label (str) {
         this.label.text = str;
         if (this.mode !== 'icon') this.label.show();
         else this.label.hide();
-    },
-});
+    }
+}
 Signals.addSignalMethods(PanelItem.prototype);

--- a/lib/panel_item.js
+++ b/lib/panel_item.js
@@ -15,10 +15,9 @@ const Signals = imports.signals;
 //     'middle-click'
 //     'right-click'
 // =====================================================================
-class PanelItem {
-    constructor (menu) {
+var PanelItem  = class PanelItem {
+    constructor(menu) {
         this.menu = menu;
-
         this.mode = 'icon_text'; // one of 'icon', 'text', 'icon_text'
 
         //
@@ -34,7 +33,6 @@ class PanelItem {
 
         this.label = new St.Label({ visible: false, y_align: Clutter.ActorAlign.CENTER });
         this.box_content.add_actor(this.label);
-
 
         //
         // listen

--- a/lib/panel_item.js
+++ b/lib/panel_item.js
@@ -1,7 +1,7 @@
 const St      = imports.gi.St;
 const Gtk     = imports.gi.Gtk;
 const Clutter = imports.gi.Clutter;
-const Lang    = imports.lang;
+
 const Signals = imports.signals;
 
 

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -28,10 +28,10 @@ const ResizeDirection = {
 // =====================================================================
 // @@@ MakeResizable
 // =====================================================================
-var MakeResizable = new Lang.Class({
-    Name: 'Timepp.MakeResizable',
+class MakeResizable {
+    
 
-    _init: function (actor) {
+    _init (actor) {
         this.actor = actor;
 
         this.actor.reactive = true;
@@ -53,9 +53,9 @@ var MakeResizable = new Lang.Class({
             MISC.global_wrapper.display.set_cursor(Meta.Cursor.DEFAULT);
             this.in_resize_pos = false;
         });
-    },
+    }
 
-    _maybe_begin_resize: function () {
+    _maybe_begin_resize () {
         if (! this.in_resize_pos) return;
 
         this.resizing = true;
@@ -68,9 +68,9 @@ var MakeResizable = new Lang.Class({
 
         this._resize();
         Main.panel.menuManager.ignoreRelease();
-    },
+    }
 
-    _update_mouse_cursor: function () {
+    _update_mouse_cursor () {
         if (this.resizing) return;
 
         let a = Shell.util_get_transformed_allocation(this.actor);
@@ -120,9 +120,9 @@ var MakeResizable = new Lang.Class({
             this.in_resize_pos = false;
             MISC.global_wrapper.display.set_cursor(Meta.Cursor.DEFAULT);
         }
-    },
+    }
 
-    _resize: function () {
+    _resize () {
         let [x, y, mask] = global.get_pointer();
 
         if (!(mask & Clutter.ModifierType.BUTTON1_MASK)) {
@@ -161,5 +161,5 @@ var MakeResizable = new Lang.Class({
         }
 
         Mainloop.idle_add(() => this._resize());
-    },
-});
+    }
+}

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -3,7 +3,7 @@ const Meta     = imports.gi.Meta;
 const Shell    = imports.gi.Shell;
 const Clutter  = imports.gi.Clutter;
 const Main     = imports.ui.main;
-const Lang     = imports.lang;
+
 const Mainloop = imports.mainloop;
 
 
@@ -31,7 +31,7 @@ const ResizeDirection = {
 class MakeResizable {
     
 
-    _init (actor) {
+    constructor (actor) {
         this.actor = actor;
 
         this.actor.reactive = true;

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -28,7 +28,7 @@ const ResizeDirection = {
 // =====================================================================
 // @@@ MakeResizable
 // =====================================================================
-class MakeResizable {
+var MakeResizable  = class MakeResizable {
     
 
     constructor (actor) {

--- a/lib/signal_manager.js
+++ b/lib/signal_manager.js
@@ -5,19 +5,19 @@ const Lang    = imports.lang;
 // =====================================================================
 // @@@ Signal Manager
 // =====================================================================
-var SignalManager = new Lang.Class({
-    Name: 'Timepp.SignalManager',
+class SignalManager {
+    
 
-    _init: function () {
+    _init () {
         this.signals = [];
-    },
+    }
 
-    clear: function () {
+    clear () {
         this.disconnect_all();
         this.signals = [];
-    },
+    }
 
-    clear_obj: function (obj) {
+    clear_obj (obj) {
         this.disconnect_obj(obj);
 
         for (let i = 0, len = this.signals.length; i < len; i++) {
@@ -26,13 +26,13 @@ var SignalManager = new Lang.Class({
                 len--; i--;
             }
         }
-    },
+    }
 
     // @obj                     : object (we connect on)
     // @button                  : event button (e.g., Clutter.BUTTON_PRIMARY)
     // @do_connect_on_key_press : bool
-    // @callback                : function
-    connect_press: function (obj, button, do_connect_on_key_press, callback) {
+    // @callback                
+    connect_press (obj, button, do_connect_on_key_press, callback) {
         let block_on_release = true;
 
         this.connect(obj, 'button-press-event', (_, event) => {
@@ -59,9 +59,9 @@ var SignalManager = new Lang.Class({
         }
 
         obj.connect('destroy', () => this.clear_obj(obj));
-    },
+    }
 
-    connect_release: function (obj, button, do_connect_on_key_release, callback) {
+    connect_release (obj, button, do_connect_on_key_release, callback) {
         this.connect(obj, 'button-release-event', (_, event) => {
             if (event.get_button() === button) callback();
         });
@@ -73,15 +73,15 @@ var SignalManager = new Lang.Class({
         }
 
         obj.connect('destroy', () => this.clear_obj(obj));
-    },
+    }
 
-    connect_on_button: function (obj, button, callback) {
+    connect_on_button (obj, button, callback) {
         this.connect(obj, 'button-release-event', (_, event) => {
             if (event.get_button() === button) callback();
         });
-    },
+    }
 
-    connect: function (obj, sig_name, callback) {
+    connect (obj, sig_name, callback) {
         let id = obj.connect(sig_name, callback);
 
         this.signals.push({
@@ -92,18 +92,18 @@ var SignalManager = new Lang.Class({
         });
 
         return id;
-    },
+    }
 
-    disconnect_obj: function (obj) {
+    disconnect_obj (obj) {
         for (let it of this.signals) {
             if (it.obj === obj && it.id > 0) {
                 it.obj.disconnect(it.id);
                 it.id = 0;
             }
         }
-    },
+    }
 
-    disconnect: function (id) {
+    disconnect (id) {
         for (let it of this.signals) {
             if (it.id === id) {
                 it.obj.disconnect(id);
@@ -111,22 +111,22 @@ var SignalManager = new Lang.Class({
                 break;
             }
         }
-    },
+    }
 
-    connect_all: function () {
+    connect_all () {
         for (let it of this.signals) {
             if (it.id === 0) {
                 it.id = it.obj.connect(it.sig_name, it.callback);
             }
         }
-    },
+    }
 
-    disconnect_all: function () {
+    disconnect_all () {
         for (let it of this.signals) {
             if (it.id > 0) {
                 it.obj.disconnect(it.id);
                 it.id = 0;
             }
         }
-    },
-});
+    }
+}

--- a/lib/signal_manager.js
+++ b/lib/signal_manager.js
@@ -3,7 +3,7 @@ const Clutter = imports.gi.Clutter;
 // =====================================================================
 // @@@ Signal Manager
 // =====================================================================
-class SignalManager {
+var SignalManager  = class SignalManager {
     constructor() {
         this.signals = [];
     }

--- a/lib/signal_manager.js
+++ b/lib/signal_manager.js
@@ -79,7 +79,7 @@ class SignalManager {
 
     connect (obj, sig_name, callback) {
         let id = obj.connect(sig_name, callback);
-
+    
         this.signals.push({
             obj      : obj,
             sig_name : sig_name,

--- a/lib/signal_manager.js
+++ b/lib/signal_manager.js
@@ -1,14 +1,10 @@
 const Clutter = imports.gi.Clutter;
-const Lang    = imports.lang;
-
 
 // =====================================================================
 // @@@ Signal Manager
 // =====================================================================
 class SignalManager {
-    
-
-    _init () {
+    constructor() {
         this.signals = [];
     }
 

--- a/lib/sound_player.js
+++ b/lib/sound_player.js
@@ -1,6 +1,6 @@
 const Gst  = imports.gi.Gst;    Gst.init(null);
 const GLib = imports.gi.GLib;
-const Lang = imports.lang;
+
 
 
 // =====================================================================
@@ -9,7 +9,7 @@ const Lang = imports.lang;
 class SoundPlayer {
     
 
-    _init () {
+    constructor () {
         this.sound_uri = '';
         this.playing   = false;
 

--- a/lib/sound_player.js
+++ b/lib/sound_player.js
@@ -1,5 +1,6 @@
 const Gst  = imports.gi.Gst;    Gst.init(null);
 const GLib = imports.gi.GLib;
+const Gio  = imports.gi.Gio;
 
 
 
@@ -35,8 +36,9 @@ var SoundPlayer  = class SoundPlayer {
             this.playbin.set_state(Gst.State.PLAYING);
             this.playing = true;
         } else {
-            let [filename,] = GLib.filename_from_uri(this.sound_uri);
-            global.play_sound_file(0, filename, '', null);
+            let file = Gio.file_new_for_uri(this.sound_uri);
+            let player = global.display.get_sound_player();
+            player.play_from_file(file, '', null);
         }
     }
 

--- a/lib/sound_player.js
+++ b/lib/sound_player.js
@@ -6,7 +6,7 @@ const GLib = imports.gi.GLib;
 // =====================================================================
 // @@@ SoundPlayer
 // =====================================================================
-class SoundPlayer {
+var SoundPlayer  = class SoundPlayer {
     
 
     constructor () {

--- a/lib/sound_player.js
+++ b/lib/sound_player.js
@@ -6,10 +6,10 @@ const Lang = imports.lang;
 // =====================================================================
 // @@@ SoundPlayer
 // =====================================================================
-var SoundPlayer = new Lang.Class({
-    Name: 'Timepp.SoundPlayer',
+class SoundPlayer {
+    
 
-    _init: function () {
+    _init () {
         this.sound_uri = '';
         this.playing   = false;
 
@@ -26,9 +26,9 @@ var SoundPlayer = new Lang.Class({
         bus.add_signal_watch();
 
         bus.connect('message', (_, msg) => this._on_message_received(msg));
-    },
+    }
 
-    play: function (do_repeat = true) {
+    play (do_repeat = true) {
         if (this.playing || !this.sound_uri) return;
 
         if (do_repeat) {
@@ -38,22 +38,22 @@ var SoundPlayer = new Lang.Class({
             let [filename,] = GLib.filename_from_uri(this.sound_uri);
             global.play_sound_file(0, filename, '', null);
         }
-    },
+    }
 
-    stop: function () {
+    stop () {
         if (! this.playing) return;
 
         this.playbin.set_state(Gst.State.NULL);
         this.playing   = false;
         this.prerolled = false;
-    },
+    }
 
-    set_sound_uri: function (sound_uri) {
+    set_sound_uri (sound_uri) {
         this.sound_uri   = sound_uri;
         this.playbin.uri = sound_uri;
-    },
+    }
 
-    _on_message_received: function (msg) {
+    _on_message_received (msg) {
         if (! msg) return;
 
         if (msg.type == Gst.MessageType.SEGMENT_DONE) {
@@ -67,5 +67,5 @@ var SoundPlayer = new Lang.Class({
         }
 
         return true;
-    },
-});
+    }
+}

--- a/lib/text_links_manager.js
+++ b/lib/text_links_manager.js
@@ -15,25 +15,25 @@ const MISC = ME.imports.lib.misc_utils;
 // =====================================================================
 // @@@ Text Links Manager
 // =====================================================================
-var TextLinksManager = new Lang.Class({
-    Name: 'Timepp.TextLinksManager',
+class TextLinksManager {
+    
 
-    _init: function () {
+    _init () {
         // @key: St.Label actor
         // @val: Map
         //     @key: regex pattern
-        //     @val: function (called when token is clicked)
+        //     @val (called when token is clicked)
         this.label_actors = new Map();
-    },
+    }
 
     // @label_actor: St.Label
     // @regex: Map
     //     @key: regex pattern
-    //     @val: function (called when token is clicked)
+    //     @val (called when token is clicked)
     //
     // If a clicked word matches a regex, then the corresponding callback is
     // executed.
-    add_label_actor: function (label_actor, regex) {
+    add_label_actor (label_actor, regex) {
         label_actor.reactive = true;
 
         let info = {
@@ -58,24 +58,24 @@ var TextLinksManager = new Lang.Class({
         label_actor.connect('destroy', () => {
             this.remove_label_actor(label_actor);
         });
-    },
+    }
 
     // @label_actor: St.Label
-    remove_label_actor: function (label_actor) {
+    remove_label_actor (label_actor) {
         for (let id of this.label_actors.get(label_actor).sig_ids) {
             label_actor.disconnect(id);
         }
 
         this.label_actors.delete(label_actor);
-    },
+    }
 
-    remove_all: function () {
+    remove_all () {
         for (let [label_actor,] of this.label_actors) {
             this.remove_label_actor(label_actor);
         }
-    },
+    }
 
-    _find_keyword: function (label_actor, event) {
+    _find_keyword (label_actor, event) {
         let info = this.label_actors.get(label_actor);
 
         let [x, y] = event.get_coords();
@@ -112,5 +112,5 @@ var TextLinksManager = new Lang.Class({
         }
 
         MISC.global_wrapper.display.set_cursor(Meta.Cursor.DEFAULT);
-    },
-});
+    }
+}

--- a/lib/text_links_manager.js
+++ b/lib/text_links_manager.js
@@ -1,5 +1,5 @@
 const Meta = imports.gi.Meta;
-const Lang = imports.lang;
+
 
 
 const ME = imports.misc.extensionUtils.getCurrentExtension();
@@ -18,7 +18,7 @@ const MISC = ME.imports.lib.misc_utils;
 class TextLinksManager {
     
 
-    _init () {
+    constructor () {
         // @key: St.Label actor
         // @val: Map
         //     @key: regex pattern

--- a/lib/text_links_manager.js
+++ b/lib/text_links_manager.js
@@ -15,7 +15,7 @@ const MISC = ME.imports.lib.misc_utils;
 // =====================================================================
 // @@@ Text Links Manager
 // =====================================================================
-class TextLinksManager {
+var TextLinksManager  = class TextLinksManager {
     
 
     constructor () {

--- a/prefs.js
+++ b/prefs.js
@@ -13,10 +13,9 @@ Gettext.bindtextdomain(ME.metadata['gettext-domain'], ME.path + '/locale');
 const _ = Gettext.domain(ME.metadata['gettext-domain']).gettext;
 
 
-const Settings = new Lang.Class({
-    Name: 'Timepp.Settings',
+class Settings{
 
-    _init: function () {
+    constructor() {
         {
             let GioSSS = Gio.SettingsSchemaSource;
             let schema = GioSSS.new_from_directory(
@@ -34,10 +33,10 @@ const Settings = new Lang.Class({
         this.switcher = new Gtk.StackSwitcher({ visible: true, stack: this.builder.get_object('settings_stack'), halign: Gtk.Align.CENTER, });
 
         this._bind_settings();
-    },
+    }
 
     // Bind the gtk window to the schema settings
-    _bind_settings: function () {
+    _bind_settings() {
         let widget;
 
         //
@@ -569,8 +568,8 @@ const Settings = new Lang.Class({
                 this.settings.set_strv('todo-keybinding-open-todotxt-file', ['']);
             }
         });
-    },
-});
+    }
+}
 
 function init () {}
 

--- a/prefs.js
+++ b/prefs.js
@@ -1,7 +1,7 @@
 const Gio      = imports.gi.Gio;
 const Gtk      = imports.gi.Gtk;
 const GLib     = imports.gi.GLib;
-const Lang     = imports.lang;
+
 const Mainloop = imports.mainloop;
 
 

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -9,7 +9,7 @@ const Main         = imports.ui.main;
 const CheckBox     = imports.ui.checkBox;
 const PopupMenu    = imports.ui.popupMenu;
 const MessageTray  = imports.ui.messageTray;
-const Lang         = imports.lang;
+
 const Signals      = imports.signals;
 const Mainloop     = imports.mainloop;
 
@@ -697,8 +697,8 @@ class AlarmItem {
         //
         // listen
         //
-        this.css_sig_id =
-            this.ext.connect('custom-css-changed', () => this._on_custom_css_updated());
+        //this.css_sig_id =
+        //   this.ext.connect('custom-css-changed', () => this._on_custom_css_updated());
         this.toggle_bin.connect('clicked', () => this._on_toggle());
         this.delegate.sigm.connect_release(this.edit_icon, Clutter.BUTTON_PRIMARY, true, () => this._on_edit());
         this.actor.connect('enter-event',  () => this.edit_icon.show());

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -697,8 +697,8 @@ class AlarmItem {
         //
         // listen
         //
-        //this.css_sig_id =
-        //   this.ext.connect('custom-css-changed', () => this._on_custom_css_updated());
+        this.css_sig_id =
+           this.ext.connect('custom-css-changed', () => this._on_custom_css_updated());
         this.toggle_bin.connect('clicked', () => this._on_toggle());
         this.delegate.sigm.connect_release(this.edit_icon, Clutter.BUTTON_PRIMARY, true, () => this._on_edit());
         this.actor.connect('enter-event',  () => this.edit_icon.show());

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -52,7 +52,7 @@ const NotifStyle = {
 // @ext      : obj (main extension object)
 // @settings : obj (extension settings)
 // =====================================================================
-class SectionMain extends ME.imports.sections.section_base.SectionBase{
+var SectionMain = class SectionMain extends ME.imports.sections.section_base.SectionBase{
 
     constructor(section_name, ext, settings) {
         super(section_name, ext, settings);
@@ -454,7 +454,7 @@ Signals.addSignalMethods(SectionMain.prototype);
 // settings; otherwise, a complete new alarm object will be returned with the
 // 'add-alarm' signal.
 // =====================================================================
-class AlarmEditor{
+var AlarmEditor = class AlarmEditor{
     constructor(ext, delegate, alarm) {
         this.ext      = ext;
         this.delegate = delegate;
@@ -634,7 +634,7 @@ Signals.addSignalMethods(AlarmEditor.prototype);
 //
 // signals: 'alarm-toggled'
 // =====================================================================
-class AlarmItem {
+var AlarmItem  = class AlarmItem {
     constructor(ext, delegate, alarm) {
         this.ext      = ext;
         this.delegate = delegate;
@@ -822,7 +822,7 @@ Signals.addSignalMethods(AlarmItem.prototype);
 //
 // signals: 'monitor-changed'
 // =====================================================================
-class AlarmFullscreen extends FULLSCREEN.Fullscreen {
+var AlarmFullscreen = class AlarmFullscreen extends FULLSCREEN.Fullscreen {
 
     constructor(ext, delegate, monitor) {
         super(monitor);

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -9,7 +9,7 @@ const Main         = imports.ui.main;
 const CheckBox     = imports.ui.checkBox;
 const PopupMenu    = imports.ui.popupMenu;
 const MessageTray  = imports.ui.messageTray;
-
+const ByteArray    = imports.byteArray;
 const Signals      = imports.signals;
 const Mainloop     = imports.mainloop;
 
@@ -58,7 +58,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         super(section_name, ext, settings);
 
         this.actor = new St.BoxLayout({ vertical: true, style_class: 'section alarm-section' });
-        this.panel_item.icon.icon_name = 'timepp-alarms-symbolic';
+        this.panel_item.icon.gicon = MISC_UTILS.getIcon('timepp-alarms-symbolic');
         this.panel_item.actor.add_style_class_name('alarm-panel-item');
         this.panel_item.set_mode('icon');
 
@@ -99,7 +99,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
 
             if (this.cache_file.query_exists(null)) {
                 let [, contents] = this.cache_file.load_contents(null);
-                this.cache = JSON.parse(contents);
+                this.cache = JSON.parse(ByteArray.toString(contents));
             }
 
             if (!this.cache || !this.cache.format_version ||
@@ -146,8 +146,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
 
             let box = new St.BoxLayout({ x_expand: true });
             this.add_alarm_button.add_actor(box);
-
-            let icon = new St.Icon({ icon_name: 'timepp-plus-symbolic' });
+            let icon = new St.Icon({ gicon: MISC_UTILS.getIcon('timepp-alarms-symbolic')});
             box.add_child(icon);
 
             let label = new St.Label({ x_expand: true, text: _('Add New Alarm...'), y_align: Clutter.ActorAlign.CENTER });
@@ -372,7 +371,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
 
             // TRANSLATORS: %s is a time string in the format HH:MM (e.g., 13:44)
             let title  = _('Alarm at %s').format(alarm.time_str);
-            let icon   = new St.Icon({ icon_name: 'timepp-alarms-symbolic' });
+            let icon   = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-alarms-symbolic') });
             let params = {
                 bannerMarkup : true,
                 gicon        : icon.gicon,
@@ -664,7 +663,7 @@ var AlarmItem  = class AlarmItem {
         this.icon_box = new St.BoxLayout({y_align: Clutter.ActorAlign.CENTER, x_align: Clutter.ActorAlign.CENTER, style_class: 'icon-box'});
         this.header.add_actor(this.icon_box);
 
-        this.edit_icon = new St.Icon({ visible: false, reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-edit-symbolic', style_class: 'settings-icon' });
+        this.edit_icon = new St.Icon({ visible: false, reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.getIcon('timepp-edit-symbolic'), style_class: 'settings-icon' });
         this.icon_box.add(this.edit_icon);
 
         this.toggle     = new PopupMenu.Switch(alarm.toggle);

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -52,12 +52,10 @@ const NotifStyle = {
 // @ext      : obj (main extension object)
 // @settings : obj (extension settings)
 // =====================================================================
-var SectionMain = new Lang.Class({
-    Name    : 'Timepp.Alarms',
-    Extends : ME.imports.sections.section_base.SectionBase,
+class SectionMain extends ME.imports.sections.section_base.SectionBase{
 
-    _init: function (section_name, ext, settings) {
-        this.parent(section_name, ext, settings);
+    constructor(section_name, ext, settings) {
+        super(section_name, ext, settings);
 
         this.actor = new St.BoxLayout({ vertical: true, style_class: 'section alarm-section' });
         this.panel_item.icon.icon_name = 'timepp-alarms-symbolic';
@@ -194,9 +192,9 @@ var SectionMain = new Lang.Class({
         //
         this.cache.alarms.forEach((a) => this._add_alarm(a));
         this._update_panel_item_UI();
-    },
+    }
 
-    disable_section: function () {
+    disable_section() {
         for (let it of this.alarm_items) it.close();
         this.sigm.clear();
         this.keym.clear();
@@ -207,18 +205,18 @@ var SectionMain = new Lang.Class({
             this.fullscreen = null;
         }
 
-        this.parent();
-    },
+        super.disable_section();
+    }
 
-    _store_cache: function () {
+    _store_cache() {
         if (! this.cache_file.query_exists(null))
             this.cache_file.create(Gio.FileCreateFlags.NONE, null);
 
         this.cache_file.replace_contents(JSON.stringify(this.cache, null, 2),
             null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
-    },
+    }
 
-    _tic: function () {
+    _tic() {
         let d    = GLib.DateTime.new_now(this.wallclock.timezone);
         let time = d.format('%H:%M');
 
@@ -249,11 +247,11 @@ var SectionMain = new Lang.Class({
         }
 
         this._update_panel_item_UI(today);
-    },
+    }
 
     // @alarm_item: obj
     // If @alarm_item is not provided, then we are adding a new alarm.
-    alarm_editor: function (alarm_item) {
+    alarm_editor(alarm_item) {
         let alarm_obj = alarm_item ? alarm_item.alarm : null;
         let editor    = new AlarmEditor(this.ext, this, alarm_obj);
 
@@ -317,11 +315,11 @@ var SectionMain = new Lang.Class({
             if (this.alarms_scroll_content.get_n_children() > 0)
                 this.alarms_scroll.show();
         });
-    },
+    }
 
     // NOTE: This func assumes that @alarm has already been added to the
     // this.cache.alarms array.
-    _add_alarm: function (alarm) {
+    _add_alarm(alarm) {
         this._update_panel_item_UI();
 
         let alarm_item = new AlarmItem(this.ext, this, alarm);
@@ -334,19 +332,19 @@ var SectionMain = new Lang.Class({
             this._update_panel_item_UI();
             this._store_cache();
         });
-    },
+    }
 
-    _delete_alarm: function (alarm) {
+    _delete_alarm (alarm) {
         this.cache.alarms = this.cache.alarms.filter(a => a !== alarm);
         this.snoozed_alarms.delete(alarm);
         this._store_cache();
         this._update_panel_item_UI();
 
         if (this.alarms_scroll_content.get_n_children() === 0)
-            this.alarms_scroll.hide();
-    },
+           this.alarms_scroll.hide();
+    }
 
-    snooze_alarm: function (alarm) {
+    snooze_alarm(alarm) {
         let t;
 
         t = GLib.DateTime.new_now(this.wallclock.timezone)
@@ -358,9 +356,9 @@ var SectionMain = new Lang.Class({
         for (let it of this.alarm_items) {
             if (it.alarm === alarm) it.update_time_label();
         }
-    },
+    }
 
-    _send_notif: function (alarm) {
+    _send_notif(alarm) {
         let notif_style = this.settings.get_enum('alarms-notif-style');
 
         if (notif_style === NotifStyle.NONE) {
@@ -399,9 +397,10 @@ var SectionMain = new Lang.Class({
             this.sound_player.set_sound_uri(this.settings.get_string('alarms-sound-file-path'));
             this.sound_player.play(alarm.repeat_sound);
         }
-    },
+    }
 
-    _update_panel_item_UI: function (today = new Date().getDay()) {
+    _update_panel_item_UI(today){
+        today = today || new Date().getDay()
         this.panel_item.actor.remove_style_class_name('on');
 
         for (let a of this.cache.alarms) {
@@ -410,9 +409,9 @@ var SectionMain = new Lang.Class({
                 break;
             }
         }
-    },
+    }
 
-    highlight_tokens: function (text) {
+    highlight_tokens(text) {
         if (! text) return "";
 
         text = GLib.markup_escape_text(text, -1);
@@ -435,8 +434,8 @@ var SectionMain = new Lang.Class({
 
         text = text.join('');
         return MISC_UTILS.markdown_to_pango(text, this.ext.markdown_map);
-    },
-});
+    }
+}
 Signals.addSignalMethods(SectionMain.prototype);
 
 
@@ -455,10 +454,8 @@ Signals.addSignalMethods(SectionMain.prototype);
 // settings; otherwise, a complete new alarm object will be returned with the
 // 'add-alarm' signal.
 // =====================================================================
-const AlarmEditor = new Lang.Class({
-    Name: 'Timepp.AlarmEditor',
-
-    _init: function(ext, delegate, alarm) {
+class AlarmEditor{
+    constructor(ext, delegate, alarm) {
         this.ext      = ext;
         this.delegate = delegate;
         this.alarm    = alarm;
@@ -617,13 +614,13 @@ const AlarmEditor = new Lang.Class({
             if (this.ext.needs_scrollbar())
                 this.entry.scroll_box.vscrollbar_policy = Gtk.PolicyType.ALWAYS;
         });
-    },
+    }
 
-    _get_time_str: function () {
+    _get_time_str() {
         return this.hh.counter_label.get_text() + ':' +
                this.mm.counter_label.get_text();
-    },
-});
+    }
+}
 Signals.addSignalMethods(AlarmEditor.prototype);
 
 
@@ -637,10 +634,8 @@ Signals.addSignalMethods(AlarmEditor.prototype);
 //
 // signals: 'alarm-toggled'
 // =====================================================================
-const AlarmItem = new Lang.Class({
-    Name: 'Timepp.AlarmItem',
-
-    _init: function(ext, delegate, alarm) {
+class AlarmItem {
+    constructor(ext, delegate, alarm) {
         this.ext      = ext;
         this.delegate = delegate;
         this.alarm    = alarm;
@@ -708,14 +703,14 @@ const AlarmItem = new Lang.Class({
         this.delegate.sigm.connect_release(this.edit_icon, Clutter.BUTTON_PRIMARY, true, () => this._on_edit());
         this.actor.connect('enter-event',  () => this.edit_icon.show());
         this.actor.connect('event', (actor, event) => this._on_event(actor, event));
-    },
+    }
 
     // @markup: string
-    set_body_text: function (markup) {
+    set_body_text(markup) {
         this.msg.clutter_text.set_markup(this.delegate.highlight_tokens(markup));
-    },
+    }
 
-    update_time_label: function () {
+    update_time_label() {
         let date   = new Date();
         let markup = `<b>${this.alarm.time_str}</b>`;
 
@@ -757,9 +752,9 @@ const AlarmItem = new Lang.Class({
         }
 
         this.time.clutter_text.set_markup(markup);
-    },
+    }
 
-    _on_toggle: function () {
+    _on_toggle() {
         this.toggle.toggle();
         this.alarm.toggle = !this.alarm.toggle;
 
@@ -770,21 +765,21 @@ const AlarmItem = new Lang.Class({
 
         this.update_time_label();
         this.emit('alarm-toggled');
-    },
+    }
 
-    _on_edit: function () {
+    _on_edit() {
         Main.panel.menuManager.ignoreRelease();
         this.edit_icon.hide();
         this.delegate.alarm_editor(this);
-    },
+    }
 
-    _on_custom_css_updated: function () {
+    _on_custom_css_updated() {
         for (let alarm_item of this.delegate.alarm_items) {
             alarm_item.set_body_text(alarm_item.alarm.msg);
         }
-    },
+    }
 
-    _on_event: function (actor, event) {
+    _on_event(actor, event) {
         switch (event.type()) {
           case Clutter.EventType.ENTER: {
             this.edit_icon.show();
@@ -807,13 +802,13 @@ const AlarmItem = new Lang.Class({
             });
           } break;
         }
-    },
+    }
 
-    close: function () {
+    close() {
         this.ext.disconnect(this.css_sig_id);
         this.actor.destroy();
-    },
-});
+    }
+}
 Signals.addSignalMethods(AlarmItem.prototype);
 
 
@@ -827,12 +822,10 @@ Signals.addSignalMethods(AlarmItem.prototype);
 //
 // signals: 'monitor-changed'
 // =====================================================================
-const AlarmFullscreen = new Lang.Class({
-    Name    : 'Timepp.AlarmFullscreen',
-    Extends : FULLSCREEN.Fullscreen,
+class AlarmFullscreen extends FULLSCREEN.Fullscreen {
 
-    _init: function (ext, delegate, monitor) {
-        this.parent(monitor);
+    constructor(ext, delegate, monitor) {
+        super(monitor);
         this.actor.add_style_class_name('alarm');
 
         this.ext      = ext;
@@ -886,20 +879,20 @@ const AlarmFullscreen = new Lang.Class({
 
             this.close();
         });
-    },
+    }
 
-    set_banner_text: function (markup) {
-        this.parent(this.delegate.highlight_tokens(markup));
-    },
+    set_banner_text(markup) {
+        super.set_banner_text(this.delegate.highlight_tokens(markup));
+    }
 
-    close: function () {
+    close() {
         this.delegate.sound_player.stop();
         this.alarms = [];
         this.alarm_cards_scroll_bin.destroy_all_children();
-        this.parent();
-    },
+        super.close();
+    }
 
-    fire_alarm: function (alarm) {
+    fire_alarm(alarm) {
         this.alarms.push(alarm);
 
         // TRANSLATORS: %s is a time string in the format HH:MM (e.g., 13:44)
@@ -932,9 +925,9 @@ const AlarmFullscreen = new Lang.Class({
         }
 
         this.open();
-    },
+    }
 
-    _add_alarm_card: function (title, msg) {
+    _add_alarm_card(title, msg) {
         let alarm_card = new St.BoxLayout({ vertical: true, style_class: 'alarm-card' });
         this.alarm_cards_scroll_bin.add_child(alarm_card);
 
@@ -960,6 +953,6 @@ const AlarmFullscreen = new Lang.Class({
 
             alarm_card.connect('allocation-changed', () => MISC_UTILS.resize_label(body));
         }
-    },
-});
+    }
+}
 Signals.addSignalMethods(AlarmFullscreen.prototype);

--- a/sections/context_menu.js
+++ b/sections/context_menu.js
@@ -22,10 +22,10 @@ const MISC_UTILS = ME.imports.lib.misc_utils;
 //
 // @ext: obj (main extension object)
 // =====================================================================
-var ContextMenu = new Lang.Class({
-    Name: 'Timepp.ContextMenu',
+class ContextMenu {
+    
 
-    _init: function (ext) {
+    constructor (ext) {
         this.actor = new St.BoxLayout({ vertical: true, style_class: 'section context-menu-section', x_expand: true });
 
 
@@ -64,8 +64,8 @@ var ContextMenu = new Lang.Class({
             MISC_UTILS.open_web_uri(ME.metadata.translations_url);
             ext.toggle_context_menu();
         });
-    },
-});
+    }
+}
 
 
 // =====================================================================
@@ -74,17 +74,15 @@ var ContextMenu = new Lang.Class({
 // @icon_name : string
 // @label     : string
 // =====================================================================
-const PopupMenuIconItem = new Lang.Class({
-    Name    : 'Timepp.PopupMenuIconItem',
-    Extends : PopupMenu.PopupBaseMenuItem,
-
-    _init: function (icon_name, label, params) {
-        this.parent(params);
+class PopupMenuIconItem extends PopupMenu.PopupBaseMenuItem{
+    
+    constructor (icon_name, label, params) {
+        super(params);
 
         this.icon = new St.Icon({ icon_name: icon_name });
         this.actor.add_child(this.icon);
 
         this.label = new St.Label({ text: label });
         this.actor.add_child(this.label);
-    },
-});
+    }
+}

--- a/sections/context_menu.js
+++ b/sections/context_menu.js
@@ -22,7 +22,7 @@ const MISC_UTILS = ME.imports.lib.misc_utils;
 //
 // @ext: obj (main extension object)
 // =====================================================================
-class ContextMenu {
+var ContextMenu  = class ContextMenu {
     
 
     constructor (ext) {
@@ -74,7 +74,7 @@ class ContextMenu {
 // @icon_name : string
 // @label     : string
 // =====================================================================
-class PopupMenuIconItem extends PopupMenu.PopupBaseMenuItem{
+var PopupMenuIconItem = class PopupMenuIconItem extends PopupMenu.PopupBaseMenuItem{
     
     constructor (icon_name, label, params) {
         super(params);

--- a/sections/context_menu.js
+++ b/sections/context_menu.js
@@ -2,7 +2,7 @@ const St        = imports.gi.St;
 const Gio       = imports.gi.Gio
 const PopupMenu = imports.ui.popupMenu;
 const Util      = imports.misc.util;
-const Lang      = imports.lang;
+
 
 
 const ME = imports.misc.extensionUtils.getCurrentExtension();

--- a/sections/context_menu.js
+++ b/sections/context_menu.js
@@ -79,7 +79,7 @@ var PopupMenuIconItem = class PopupMenuIconItem extends PopupMenu.PopupBaseMenuI
     constructor (icon_name, label, params) {
         super(params);
 
-        this.icon = new St.Icon({ icon_name: icon_name });
+        this.icon = new St.Icon({ gicon: MISC_UTILS.getIcon(icon_name) });
         this.actor.add_child(this.icon);
 
         this.label = new St.Label({ text: label });

--- a/sections/pomodoro.js
+++ b/sections/pomodoro.js
@@ -5,7 +5,7 @@ const Clutter     = imports.gi.Clutter;
 const MessageTray = imports.ui.messageTray;
 const Main        = imports.ui.main;
 const CheckBox    = imports.ui.checkBox;
-
+const ByteArray   = imports.byteArray;
 const Signals     = imports.signals;
 const Mainloop    = imports.mainloop;
 
@@ -68,7 +68,7 @@ const PanelMode = {
 // @ext      : obj (main extension object)
 // @settings : obj (extension settings)
 // =====================================================================
-class SectionMain extends ME.imports.sections.section_base.SectionBase{
+var SectionMain = class SectionMain extends ME.imports.sections.section_base.SectionBase{
     
     constructor (section_name, ext, settings) {
         super(section_name, ext, settings);
@@ -100,7 +100,7 @@ class SectionMain extends ME.imports.sections.section_base.SectionBase{
 
         {
             let [,xml,] = Gio.file_new_for_path(IFACE).load_contents(null);
-            xml = '' + xml;
+            xml = '' + ByteArray.toString(xml);
             this.dbus_impl = Gio.DBusExportedObject.wrapJSObject(xml, this);
             this.dbus_impl.export(Gio.DBus.session, '/timepp/zagortenay333/Pomodoro');
         }
@@ -114,7 +114,7 @@ class SectionMain extends ME.imports.sections.section_base.SectionBase{
 
             if (this.cache_file.query_exists(null)) {
                 let [, contents] = this.cache_file.load_contents(null);
-                this.cache = JSON.parse(contents);
+                this.cache = JSON.parse(ByteArray.toString(contents));
             }
 
             if (!this.cache || !this.cache.format_version ||
@@ -651,7 +651,7 @@ Signals.addSignalMethods(SectionMain.prototype);
 //
 // @signals: 'ok', 'cancel'
 // =====================================================================
-class PomodoroSettings {
+var PomodoroSettings  = class PomodoroSettings {
     
 
     constructor(ext, delegate, pomo_cache) {
@@ -837,7 +837,7 @@ Signals.addSignalMethods(PomodoroSettings.prototype);
 //
 // signals: 'monitor-changed'
 // =====================================================================
-class PomodoroFullscreen extends FULLSCREEN.Fullscreen {
+var PomodoroFullscreen  = class PomodoroFullscreen extends FULLSCREEN.Fullscreen {
     
     constructor (ext, delegate, monitor) {
         super(monitor);

--- a/sections/pomodoro.js
+++ b/sections/pomodoro.js
@@ -68,12 +68,10 @@ const PanelMode = {
 // @ext      : obj (main extension object)
 // @settings : obj (extension settings)
 // =====================================================================
-var SectionMain = new Lang.Class({
-    Name    : 'Timepp.Pomodoro',
-    Extends : ME.imports.sections.section_base.SectionBase,
-
-    _init: function (section_name, ext, settings) {
-        this.parent(section_name, ext, settings);
+class SectionMain extends ME.imports.sections.section_base.SectionBase{
+    
+    constructor (section_name, ext, settings) {
+        super(section_name, ext, settings);
 
         this.actor.add_style_class_name('pomo-section');
 
@@ -243,9 +241,9 @@ var SectionMain = new Lang.Class({
 
         this._update_time_display();
         this.header_label.text = _('Pomodoro');
-    },
+    }
 
-    disable_section: function () {
+    disable_section () {
         this.dbus_impl.unexport();
         this.stop();
         this._store_cache();
@@ -257,18 +255,18 @@ var SectionMain = new Lang.Class({
             this.fullscreen = null;
         }
 
-        this.parent();
-    },
+        super.disable_section();
+    }
 
-    _store_cache: function () {
+    _store_cache () {
         if (! this.cache_file.query_exists(null))
             this.cache_file.create(Gio.FileCreateFlags.NONE, null);
 
         this.cache_file.replace_contents(JSON.stringify(this.cache, null, 2),
             null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
-    },
+    }
 
-    _show_settings: function () {
+    _show_settings () {
         let settings = new PomodoroSettings(this.ext, this, this.cache);
         this.settings_container.add_actor(settings.actor);
         settings.button_cancel.grab_key_focus();
@@ -302,9 +300,9 @@ var SectionMain = new Lang.Class({
             settings.actor.destroy();
             this.header.show();
         });
-    },
+    }
 
-    show_fullscreen: function () {
+    show_fullscreen () {
         this.ext.menu.close();
 
         if (! this.fullscreen) {
@@ -313,28 +311,28 @@ var SectionMain = new Lang.Class({
         }
 
         this.fullscreen.open();
-    },
+    }
 
-    clear_pomo_counter: function () {
+    clear_pomo_counter () {
         this.cache.pomo_counter = 0;
         this.clock_label.text = '';
         this._store_cache();
-    },
+    }
 
     // @pomo        : int (seconds)
     // @short_break : int (seconds)
     // @long_break  : int (seconds)
     // @break_rate  : int (num of pomos until long break)
-    set_phase_durations: function (pomo, short_break, long_break, break_rate) {
+    set_phase_durations (pomo, short_break, long_break, break_rate) {
         this.cache.pomo_duration   = Math.max(1, pomo);
         this.cache.short_break     = Math.max(1, short_break);
         this.cache.long_break      = Math.max(1, long_break);
         this.cache.long_break_rate = Math.max(1, break_rate);
 
         this._store_cache();
-    },
+    }
 
-    stop: function () {
+    stop () {
         this.clock = this.end_time - GLib.get_monotonic_time();
 
         if (this.tic_mainloop_id) {
@@ -384,14 +382,14 @@ var SectionMain = new Lang.Class({
         if (this.cache.todo_task_id) {
             this.ext.emit_to_sections('stop-time-tracking-by-id', this.section_name, this.cache.todo_task_id);
         }
-    },
+    }
 
-    start_new_pomo: function () {
+    start_new_pomo () {
         this.start_pomo(this.cache.pomo_duration);
-    },
+    }
 
     // @time: int (seconds)
-    start_pomo: function (time) {
+    start_pomo (time) {
         if (this.tic_mainloop_id) {
             Mainloop.source_remove(this.tic_mainloop_id);
             this.tic_mainloop_id = null;
@@ -430,9 +428,9 @@ var SectionMain = new Lang.Class({
         if (this.cache.todo_task_id) {
             this.ext.emit_to_sections('start-time-tracking-by-id', this.section_name, this.cache.todo_task_id);
         }
-    },
+    }
 
-    take_break: function () {
+    take_break () {
         if (this.tic_mainloop_id) {
             Mainloop.source_remove(this.tic_mainloop_id);
             this.tic_mainloop_id = null;
@@ -473,16 +471,16 @@ var SectionMain = new Lang.Class({
         this._tic();
 
         this.dbus_impl.emit_signal('pomo_state_changed', GLib.Variant.new('(s)', [this.pomo_state]));
-    },
+    }
 
-    timer_toggle: function () {
+    timer_toggle () {
         if (this.pomo_state === PomoState.STOPPED)
             this.start_pomo();
         else
             this.stop();
-    },
+    }
 
-    _update_time_display: function () {
+    _update_time_display () {
         let time = Math.ceil(this.clock / 1000000);
         let txt;
 
@@ -506,9 +504,9 @@ var SectionMain = new Lang.Class({
         this.header_label.text = txt;
         this.panel_item.set_label(txt);
         this.fullscreen.set_banner_text(txt);
-    },
+    }
 
-    _update_phase_label: function () {
+    _update_phase_label () {
         switch (this.pomo_state) {
           case PomoState.POMO:
             this.phase_label.text            = POMO_STARTED_MSG;
@@ -527,16 +525,16 @@ var SectionMain = new Lang.Class({
             this.fullscreen.phase_label.text = '';
             break;
         }
-    },
+    }
 
-    _update_panel_item: function () {
+    _update_panel_item () {
         if (this.pomo_state === PomoState.STOPPED)
             this.panel_item.actor.remove_style_class_name('on');
         else
             this.panel_item.actor.add_style_class_name('on');
-    },
+    }
 
-    _timer_expired: function () {
+    _timer_expired () {
         if (this.pomo_state === PomoState.LONG_BREAK ||
             this.pomo_state === PomoState.SHORT_BREAK) {
 
@@ -550,9 +548,9 @@ var SectionMain = new Lang.Class({
         }
 
         this._send_notif();
-    },
+    }
 
-    _tic: function () {
+    _tic () {
         this.clock = this.end_time - GLib.get_monotonic_time();
 
         if (this.clock <= 0) {
@@ -566,9 +564,9 @@ var SectionMain = new Lang.Class({
         this.tic_mainloop_id = Mainloop.timeout_add_seconds(1, () => {
             this._tic();
         });
-    },
+    }
 
-    _send_notif: function () {
+    _send_notif () {
         let do_play_sound, msg;
 
         switch (this.pomo_state) {
@@ -620,9 +618,9 @@ var SectionMain = new Lang.Class({
 
         if (do_play_sound)
             this.sound_player.play(this.settings.get_boolean('pomodoro-do-repeat-notif-sound'));
-    },
+    }
 
-    _toggle_panel_mode: function () {
+    _toggle_panel_mode () {
         switch (this.settings.get_enum('pomodoro-panel-mode')) {
           case PanelMode.ICON:
             this.panel_item.set_mode('icon');
@@ -639,8 +637,8 @@ var SectionMain = new Lang.Class({
             else
                 this.panel_item.set_mode('icon_text');
         }
-    },
-});
+    }
+}
 Signals.addSignalMethods(SectionMain.prototype);
 
 
@@ -653,10 +651,10 @@ Signals.addSignalMethods(SectionMain.prototype);
 //
 // @signals: 'ok', 'cancel'
 // =====================================================================
-const PomodoroSettings = new Lang.Class({
-    Name: 'Timepp.PomodoroSettings',
+class PomodoroSettings {
+    
 
-    _init: function(ext, delegate, pomo_cache) {
+    constructor(ext, delegate, pomo_cache) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -824,8 +822,8 @@ const PomodoroSettings = new Lang.Class({
             if (n === 0 && this.short_break_min_picker.counter === 0)
                 this.short_break_sec_picker.set_counter(1);
         });
-    },
-});
+    }
+}
 Signals.addSignalMethods(PomodoroSettings.prototype);
 
 
@@ -839,12 +837,10 @@ Signals.addSignalMethods(PomodoroSettings.prototype);
 //
 // signals: 'monitor-changed'
 // =====================================================================
-const PomodoroFullscreen = new Lang.Class({
-    Name    : 'Timepp.PomodoroFullscreen',
-    Extends : FULLSCREEN.Fullscreen,
-
-    _init: function (ext, delegate, monitor) {
-        this.parent(monitor);
+class PomodoroFullscreen extends FULLSCREEN.Fullscreen {
+    
+    constructor (ext, delegate, monitor) {
+        super(monitor);
 
         this.ext      = ext;
         this.delegate = delegate;
@@ -903,14 +899,14 @@ const PomodoroFullscreen = new Lang.Class({
                 return Clutter.EVENT_PROPAGATE;
             }
         });
-    },
+    }
 
-    close: function () {
+    close () {
         this.delegate.sound_player.stop();
-        this.parent();
-    },
+        super.close();
+    }
 
-    on_start: function () {
+    on_start () {
         switch (this.delegate.pomo_state) {
           case PomoState.POMO:
             this.actor.style_class = this.default_style_class + ' pomo-running';
@@ -922,19 +918,19 @@ const PomodoroFullscreen = new Lang.Class({
             this.actor.style_class = this.default_style_class + ' pomo-short-break';
             break;
         }
-    },
+    }
 
-    on_stop: function () {
+    on_stop () {
         this.actor.style_class = this.default_style_class + ' pomo-stopped';
         this.phase_label.text  = '';
-    },
+    }
 
-    on_new_pomo: function () {
+    on_new_pomo () {
         this.actor.style_class = this.default_style_class + ' pomo-running';
         this.phase_label.text  = POMO_STARTED_MSG;
-    },
+    }
 
-    on_break: function () {
+    on_break () {
         switch (this.delegate.pomo_state) {
           case PomoState.LONG_BREAK:
             this.actor.style_class = this.default_style_class + ' pomo-long-break';
@@ -945,6 +941,6 @@ const PomodoroFullscreen = new Lang.Class({
             this.phase_label.text  = SHORT_BREAK_MSG;
             break;
         }
-    },
-});
+    }
+}
 Signals.addSignalMethods(PomodoroFullscreen.prototype);

--- a/sections/pomodoro.js
+++ b/sections/pomodoro.js
@@ -5,7 +5,7 @@ const Clutter     = imports.gi.Clutter;
 const MessageTray = imports.ui.messageTray;
 const Main        = imports.ui.main;
 const CheckBox    = imports.ui.checkBox;
-const Lang        = imports.lang;
+
 const Signals     = imports.signals;
 const Mainloop    = imports.mainloop;
 

--- a/sections/pomodoro.js
+++ b/sections/pomodoro.js
@@ -151,7 +151,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         // panel item
         //
         this.panel_item.actor.add_style_class_name('pomodoro-panel-item');
-        this.panel_item.icon.icon_name = 'timepp-pomodoro-symbolic';
+        this.panel_item.icon.gicon = MISC_UTILS.getIcon('timepp-pomodoro-symbolic');
         this.panel_item.set_label(this.settings.get_boolean('pomodoro-show-seconds') ? '00:00:00' : '00:00');
         this._toggle_panel_mode();
 
@@ -180,10 +180,10 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         this.icon_box = new St.BoxLayout({ y_align: Clutter.ActorAlign.CENTER, x_align: Clutter.ActorAlign.END, style_class: 'icon-box' });
         this.header.add_actor(this.icon_box);
 
-        this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-fullscreen-symbolic', style_class: 'fullscreen-icon' });
+        this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.getIcon('timepp-fullscreen-symbolic'), style_class: 'fullscreen-icon' });
         this.icon_box.add_actor(this.fullscreen_icon);
 
-        this.settings_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-settings-symbolic', style_class: 'settings-icon' });
+        this.settings_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.getIcon('timepp-settings-symbolic'), style_class: 'settings-icon' });
         this.icon_box.add_actor(this.settings_icon);
 
 
@@ -604,7 +604,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
             Main.messageTray.add(this.notif_source);
             this.notif_source.connect('destroy', () => this.sound_player.stop());
 
-            let icon   = new St.Icon({ icon_name: 'timepp-pomodoro-symbolic' });
+            let icon   = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-pomodoro-symbolic') });
             let params = {
                 bannerMarkup : true,
                 gicon        : icon.gicon,

--- a/sections/section_base.js
+++ b/sections/section_base.js
@@ -19,10 +19,10 @@ const PANEL_ITEM = ME.imports.lib.panel_item;
 // @signals:
 //     - 'section-open-state-changed' returns bool
 // =====================================================================
-var SectionBase = new Lang.Class({
-    Name: 'Timepp.SectionBase',
+class SectionBase {
+    
 
-    _init: function (section_name, ext, settings) {
+    _init (section_name, ext, settings) {
         this.section_name = section_name;
         this.ext          = ext;
         this.settings     = settings;
@@ -40,14 +40,14 @@ var SectionBase = new Lang.Class({
         this.panel_item.connect('right-click', () => this.ext.toggle_context_menu(this.section_name));
         this.panel_item.actor.connect('enter-event', () => { if (Main.panel.menuManager.activeMenu) this.ext.open_menu(this.section_name)});
         this.panel_item.actor.connect('key-focus-in', () => this.ext.open_menu(this.section_name));
-    },
+    }
 
-    disable_section: function () {
+    disable_section () {
         this.panel_item.actor.destroy();
         this.actor.destroy();
-    },
+    }
 
-    on_section_open_state_changed: function (state) {
+    on_section_open_state_changed (state) {
         if (state) {
             this.panel_item.actor.add_style_pseudo_class('checked');
             this.panel_item.actor.can_focus = false;
@@ -58,5 +58,5 @@ var SectionBase = new Lang.Class({
         }
 
         this.emit('section-open-state-changed', state);
-    },
-});
+    }
+}

--- a/sections/section_base.js
+++ b/sections/section_base.js
@@ -21,8 +21,7 @@ const PANEL_ITEM = ME.imports.lib.panel_item;
 // =====================================================================
 class SectionBase {
     
-
-    constructor (section_name, ext, settings) {
+    constructor(section_name, ext, settings) {
         this.section_name = section_name;
         this.ext          = ext;
         this.settings     = settings;

--- a/sections/section_base.js
+++ b/sections/section_base.js
@@ -1,6 +1,6 @@
 const St   = imports.gi.St;
 const Main = imports.ui.main;
-const Lang = imports.lang;
+
 
 
 const ME = imports.misc.extensionUtils.getCurrentExtension();
@@ -22,7 +22,7 @@ const PANEL_ITEM = ME.imports.lib.panel_item;
 class SectionBase {
     
 
-    _init (section_name, ext, settings) {
+    constructor (section_name, ext, settings) {
         this.section_name = section_name;
         this.ext          = ext;
         this.settings     = settings;

--- a/sections/section_base.js
+++ b/sections/section_base.js
@@ -19,7 +19,7 @@ const PANEL_ITEM = ME.imports.lib.panel_item;
 // @signals:
 //     - 'section-open-state-changed' returns bool
 // =====================================================================
-class SectionBase {
+var SectionBase = class SectionBase {
     
     constructor(section_name, ext, settings) {
         this.section_name = section_name;

--- a/sections/stopwatch.js
+++ b/sections/stopwatch.js
@@ -4,7 +4,7 @@ const Gtk       = imports.gi.Gtk;
 const GLib      = imports.gi.GLib;
 const Clutter   = imports.gi.Clutter;
 const Main      = imports.ui.main;
-const Lang      = imports.lang;
+
 const Signals   = imports.signals;
 const Mainloop  = imports.mainloop;
 

--- a/sections/stopwatch.js
+++ b/sections/stopwatch.js
@@ -64,12 +64,10 @@ const PanelMode = {
 // @ext      : obj (main extension object)
 // @settings : obj (extension settings)
 // =====================================================================
-var SectionMain = new Lang.Class({
-    Name    : 'Timepp.Stopwatch',
-    Extends : ME.imports.sections.section_base.SectionBase,
+class SectionMain extends ME.imports.sections.section_base.SectionBase{
 
-    _init: function (section_name, ext, settings) {
-        this.parent(section_name, ext, settings);
+    constructor (section_name, ext, settings) {
+        super(section_name, ext, settings);
 
         this.actor.add_style_class_name('stopwatch-section');
 
@@ -243,9 +241,9 @@ var SectionMain = new Lang.Class({
             this._update_time_display();
             this.stopwatch_state = StopwatchState.STOPPED;
         }
-    },
+    }
 
-    disable_section: function () {
+    disable_section () {
         if (this.time_backup_mainloop_id) {
             Mainloop.source_remove(this.time_backup_mainloop_id);
             this.time_backup_mainloop_id = null;
@@ -262,18 +260,18 @@ var SectionMain = new Lang.Class({
             this.fullscreen = null;
         }
 
-        this.parent();
-    },
+        super.disable_section();
+    }
 
-    _store_cache: function () {
+    _store_cache () {
         if (! this.cache_file.query_exists(null))
             this.cache_file.create(Gio.FileCreateFlags.NONE, null);
 
         this.cache_file.replace_contents(JSON.stringify(this.cache, null, 2),
             null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
-    },
+    }
 
-    start: function () {
+    start () {
         this.start_time = GLib.get_monotonic_time() - this.cache.time;
         this.stopwatch_state = StopwatchState.RUNNING;
 
@@ -291,9 +289,9 @@ var SectionMain = new Lang.Class({
 
         this._store_cache();
         this._tic();
-    },
+    }
 
-    stop: function () {
+    stop () {
         if (this.start_time) this.cache.time = GLib.get_monotonic_time() - this.start_time;
         this.stopwatch_state = StopwatchState.STOPPED;
 
@@ -319,9 +317,9 @@ var SectionMain = new Lang.Class({
             this.panel_item.set_mode('icon');
 
         this._store_cache();
-    },
+    }
 
-    reset: function () {
+    reset () {
         this.stopwatch_state = StopwatchState.RESET;
 
         if (this.tic_mainloop_id) {
@@ -352,16 +350,16 @@ var SectionMain = new Lang.Class({
             this.panel_item.set_mode('icon');
 
         this._store_cache();
-    },
+    }
 
-    stopwatch_toggle: function () {
+    stopwatch_toggle () {
         if (this.stopwatch_state === StopwatchState.RUNNING)
             this.stop();
         else
             this.start();
-    },
+    }
 
-    _tic: function () {
+    _tic () {
         this.cache.time = GLib.get_monotonic_time() - this.start_time;
 
         this._update_time_display();
@@ -371,17 +369,17 @@ var SectionMain = new Lang.Class({
         } else {
             this.tic_mainloop_id = Mainloop.timeout_add_seconds(1, () => this._tic());
         }
-    },
+    }
 
-    _update_time_display: function () {
+    _update_time_display () {
         let txt = this._time_format_str();
 
         this.header_label.text = txt;
         this.panel_item.set_label(txt);
         this.fullscreen.set_banner_text(txt);
-    },
+    }
 
-    _time_format_str: function () {
+    _time_format_str () {
         let t   = Math.floor(this.cache.time / 10000); // centiseconds
 
         let cs  = t % 100;
@@ -399,24 +397,24 @@ var SectionMain = new Lang.Class({
           case ClockFormat.H_M_S_CS:
             return "%02d:%02d:%02d.%02d".format(h, m, s, cs);
         }
-    },
+    }
 
-    _panel_item_UI_update: function () {
+    _panel_item_UI_update () {
         if (this.stopwatch_state === StopwatchState.RUNNING)
             this.panel_item.actor.add_style_class_name('on');
         else
             this.panel_item.actor.remove_style_class_name('on');
-    },
+    }
 
-    lap: function () {
+    lap () {
         if (this.stopwatch_state !== StopwatchState.RUNNING) return;
 
         this.cache.laps.push(this._time_format_str());
         this._store_cache();
         this._update_laps();
-    },
+    }
 
-    _update_laps: function () {
+    _update_laps () {
         let n = this.cache.laps.length;
 
         if (n === 0) return;
@@ -436,14 +434,14 @@ var SectionMain = new Lang.Class({
         this.fullscreen.laps_string.clutter_text.set_markup(markup);
         this.laps_scroll.show();
         this.fullscreen.laps_scroll.show();
-    },
+    }
 
-    _destroy_laps: function () {
+    _destroy_laps () {
         this.laps_scroll.hide();
         this.laps_string.text = '';
-    },
+    }
 
-    _toggle_buttons: function () {
+    _toggle_buttons () {
         switch (this.stopwatch_state) {
           case StopwatchState.RESET:
             this.button_reset.hide();
@@ -483,9 +481,9 @@ var SectionMain = new Lang.Class({
             this.fullscreen.button_start.remove_style_pseudo_class('first-child');
             this.fullscreen.button_start.add_style_pseudo_class('last-child');
         }
-    },
+    }
 
-    show_fullscreen: function () {
+    show_fullscreen () {
         this.ext.menu.close();
 
         if (! this.fullscreen) {
@@ -494,18 +492,18 @@ var SectionMain = new Lang.Class({
         }
 
         this.fullscreen.open();
-    },
+    }
 
-    _periodic_time_backup: function () {
+    _periodic_time_backup () {
         this.cache.time = GLib.get_monotonic_time() - this.start_time;
         this._store_cache();
 
         this.time_backup_mainloop_id = Mainloop.timeout_add_seconds(60, () => {
             this._periodic_time_backup();
         });
-    },
+    }
 
-    _toggle_panel_mode: function () {
+    _toggle_panel_mode () {
         switch (this.settings.get_enum('stopwatch-panel-mode')) {
           case PanelMode.ICON:
             this.panel_item.set_mode('icon');
@@ -522,16 +520,16 @@ var SectionMain = new Lang.Class({
             else
                 this.panel_item.set_mode('icon');
         }
-    },
+    }
 
     // returns int (microseconds)
-    get_time: function () {
+    get_time () {
         if (this.stopwatch_state === StopwatchState.RUNNING)
             return GLib.get_monotonic_time() - this.start_time;
         else
             return this.cache.time;
-    },
-});
+    }
+}
 Signals.addSignalMethods(SectionMain.prototype);
 
 
@@ -545,12 +543,10 @@ Signals.addSignalMethods(SectionMain.prototype);
 //
 // signals: 'monitor-changed'
 // =====================================================================
-const StopwatchFullscreen = new Lang.Class({
-    Name    : 'Timepp.StopwatchFullscreen',
-    Extends : FULLSCREEN.Fullscreen,
-
-    _init: function (ext, delegate, monitor) {
-        this.parent(monitor);
+class StopwatchFullscreen extends FULLSCREEN.Fullscreen{
+    
+    constructor (ext, delegate, monitor) {
+        super(monitor);
         this.middle_box.vertical = false;
 
         this.ext      = ext;
@@ -628,9 +624,9 @@ const StopwatchFullscreen = new Lang.Class({
                 return Clutter.EVENT_PROPAGATE;
             }
         });
-    },
+    }
 
-    close: function () {
+    close () {
         if (this.delegate.stopwatch_state === StopwatchState.RESET) {
             this.actor.style_class = this.default_style_class;
 
@@ -647,20 +643,20 @@ const StopwatchFullscreen = new Lang.Class({
             }
         }
 
-        this.parent();
-    },
+        super.close();
+    }
 
-    on_timer_started: function () {
+    on_timer_started () {
         this.actor.style_class = this.default_style_class;
-    },
+    }
 
-    on_timer_stopped: function () {
+    on_timer_stopped () {
         this.actor.style_class = this.default_style_class + ' timer-stopped';
-    },
+    }
 
-    on_timer_reset: function () {
+    on_timer_reset () {
         this.laps_scroll.hide();
         this.laps_string.text = '';
-    },
-});
+    }
+}
 Signals.addSignalMethods(StopwatchFullscreen.prototype);

--- a/sections/stopwatch.js
+++ b/sections/stopwatch.js
@@ -4,7 +4,7 @@ const Gtk       = imports.gi.Gtk;
 const GLib      = imports.gi.GLib;
 const Clutter   = imports.gi.Clutter;
 const Main      = imports.ui.main;
-
+const ByteArray = imports.byteArray;
 const Signals   = imports.signals;
 const Mainloop  = imports.mainloop;
 
@@ -64,7 +64,7 @@ const PanelMode = {
 // @ext      : obj (main extension object)
 // @settings : obj (extension settings)
 // =====================================================================
-class SectionMain extends ME.imports.sections.section_base.SectionBase{
+var SectionMain = class SectionMain extends ME.imports.sections.section_base.SectionBase{
 
     constructor (section_name, ext, settings) {
         super(section_name, ext, settings);
@@ -84,7 +84,7 @@ class SectionMain extends ME.imports.sections.section_base.SectionBase{
 
         {
             let [,xml,] = Gio.file_new_for_path(IFACE).load_contents(null);
-            xml = '' + xml;
+            xml = '' + ByteArray.toString(xml);
             this.dbus_impl = Gio.DBusExportedObject.wrapJSObject(xml, this);
             this.dbus_impl.export(Gio.DBus.session, '/timepp/zagortenay333/Stopwatch');
         }
@@ -104,7 +104,7 @@ class SectionMain extends ME.imports.sections.section_base.SectionBase{
 
             if (this.cache_file.query_exists(null)) {
                 let [a, contents, b] = this.cache_file.load_contents(null);
-                this.cache = JSON.parse(contents);
+                this.cache = JSON.parse(ByteArray.toString(contents));
             }
 
             if (!this.cache || !this.cache.format_version ||
@@ -543,7 +543,7 @@ Signals.addSignalMethods(SectionMain.prototype);
 //
 // signals: 'monitor-changed'
 // =====================================================================
-class StopwatchFullscreen extends FULLSCREEN.Fullscreen{
+var StopwatchFullscreen = class StopwatchFullscreen extends FULLSCREEN.Fullscreen{
     
     constructor (ext, delegate, monitor) {
         super(monitor);

--- a/sections/stopwatch.js
+++ b/sections/stopwatch.js
@@ -136,7 +136,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         //
         // panel item
         //
-        this.panel_item.icon.icon_name = 'timepp-stopwatch-symbolic';
+        this.panel_item.icon.gicon = MISC_UTILS.getIcon('timepp-stopwatch-symbolic');
         this.panel_item.actor.add_style_class_name('stopwatch-panel-item');
         this._toggle_panel_mode();
 
@@ -167,7 +167,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         this.icon_box = new St.BoxLayout({ y_align: Clutter.ActorAlign.CENTER, x_align: Clutter.ActorAlign.END, style_class: 'icon-box' });
         this.header.add_child(this.icon_box);
 
-        this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-fullscreen-symbolic', style_class: 'fullscreen-icon' });
+        this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.getIcon('timepp-fullscreen-symbolic'), style_class: 'fullscreen-icon' });
         this.icon_box.add_actor(this.fullscreen_icon);
 
 

--- a/sections/timer.js
+++ b/sections/timer.js
@@ -7,7 +7,7 @@ const Main        = imports.ui.main;
 const CheckBox    = imports.ui.checkBox;
 const MessageTray = imports.ui.messageTray;
 const Slider      = imports.ui.slider;
-const Lang        = imports.lang;
+
 const Signals     = imports.signals;
 const Mainloop    = imports.mainloop;
 

--- a/sections/timer.js
+++ b/sections/timer.js
@@ -163,7 +163,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         //
         // panel item
         //
-        this.panel_item.icon.icon_name = 'timepp-timer-symbolic';
+        this.panel_item.icon.gicon = MISC_UTILS.getIcon('timepp-timer-symbolic');
         this.panel_item.actor.add_style_class_name('timer-panel-item');
         this.panel_item.set_label(this.settings.get_boolean('timer-show-seconds') ? '00:00:00' : '00:00');
         this._toggle_panel_item_mode();
@@ -181,13 +181,13 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         this.icon_box = new St.BoxLayout({ y_align: Clutter.ActorAlign.CENTER, style_class: 'icon-box' });
         this.header.add(this.icon_box);
 
-        this.start_pause_icon = new St.Icon({ visible: false, reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-pause-symbolic', style_class: 'pause-icon' });
+        this.start_pause_icon = new St.Icon({ visible: false, reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.getIcon('timepp-pause-symbolic'), style_class: 'pause-icon' });
         this.icon_box.add_actor(this.start_pause_icon);
 
-        this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-fullscreen-symbolic', style_class: 'fullscreen-icon' });
+        this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.getIcon('timepp-fullscreen-symbolic'), style_class: 'fullscreen-icon' });
         this.icon_box.add_actor(this.fullscreen_icon);
 
-        this.settings_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-settings-symbolic', style_class: 'settings-icon' });
+        this.settings_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.getIcon('timepp-settings-symbolic'), style_class: 'settings-icon' });
         this.icon_box.add(this.settings_icon);
 
 
@@ -303,7 +303,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
 
         this.fullscreen.on_timer_started();
         this.start_pause_icon.show();
-        this.start_pause_icon.icon_name   = 'timepp-pause-symbolic';
+        this.start_pause_icon.gicon = MISC_UTILS.getIcon('timepp-pause-symbolic');
         this.start_pause_icon.style_class = 'pause-icon';
         this.panel_item.actor.add_style_class_name('on');
 
@@ -324,7 +324,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         }
 
         this.fullscreen.on_timer_stopped();
-        this.start_pause_icon.icon_name   = 'timepp-start-symbolic';
+        this.start_pause_icon.gicon = MISC_UTILS.getIcon('timepp-start-symbolic');
         this.start_pause_icon.style_class = 'start-icon';
         this.panel_item.actor.remove_style_class_name('on');
 
@@ -473,7 +473,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
             Main.messageTray.add(this.notif_source);
             this.notif_source.connect('destroy', () => this.sound_player.stop());
 
-            let icon = new St.Icon({ icon_name: 'timepp-timer-symbolic' });
+            let icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-timer-symbolic') });
             let params = {
                 bannerMarkup : true,
                 gicon        : icon.gicon,
@@ -837,10 +837,10 @@ var TimerPresetsView  = class TimerPresetsView {
         item.icon_box = new St.BoxLayout({ visible: false, style_class: 'icon-box' });
         item.header.add_child(item.icon_box);
 
-        let start_icon = new St.Icon({ track_hover: true, can_focus: true, reactive: true, icon_name: 'timepp-start-symbolic' });
+        let start_icon = new St.Icon({ track_hover: true, can_focus: true, reactive: true, gicon : MISC_UTILS.getIcon('timepp-start-symbolic') });
         item.icon_box.add_child(start_icon);
 
-        let edit_icon = new St.Icon({ track_hover: true, can_focus: true, reactive: true, icon_name: 'timepp-edit-symbolic' });
+        let edit_icon = new St.Icon({ track_hover: true, can_focus: true, reactive: true, gicon : MISC_UTILS.getIcon('timepp-edit-symbolic') });
         item.icon_box.add_child(edit_icon);
 
 
@@ -1083,7 +1083,7 @@ var TimerFullscreen = class TimerFullscreen extends FULLSCREEN.Fullscreen {
 
         this.start_pause_btn = new St.Button();
         this.top_box.insert_child_at_index(this.start_pause_btn, 0);
-        this.start_pause_icon = new St.Icon({ visible: false, reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-pause-symbolic', style_class: 'pause-icon' });
+        this.start_pause_icon = new St.Icon({ visible: false, reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.getIcon('timepp-pause-symbolic'), style_class: 'pause-icon' });
         this.start_pause_btn.add_actor(this.start_pause_icon);
 
 
@@ -1168,14 +1168,14 @@ var TimerFullscreen = class TimerFullscreen extends FULLSCREEN.Fullscreen {
     on_timer_started () {
         this.actor.style_class = this.default_style_class;
         this.title.text = '';
-        this.start_pause_icon.icon_name   = 'timepp-pause-symbolic';
+        this.start_pause_icon.gicon = MISC_UTILS.getIcon('timepp-pause-symbolic');
         this.start_pause_icon.style_class = 'pause-icon';
         this.start_pause_icon.show();
     }
 
     on_timer_stopped () {
         this.actor.style_class = this.default_style_class + ' timer-stopped';
-        this.start_pause_icon.icon_name = 'timepp-start-symbolic';
+        this.start_pause_icon.gicon = MISC_UTILS.getIcon('timepp-start-symbolic');
         this.start_pause_icon.style_class = 'start-icon';
     }
 

--- a/sections/timer.js
+++ b/sections/timer.js
@@ -71,12 +71,10 @@ const PanelMode = {
 // @ext      : obj (main extension object)
 // @settings : obj (extension settings)
 // =====================================================================
-var SectionMain = new Lang.Class({
-    Name    : 'Timepp.Timer',
-    Extends : ME.imports.sections.section_base.SectionBase,
-
-    _init: function (section_name, ext, settings) {
-        this.parent(section_name, ext, settings);
+class SectionMain extends ME.imports.sections.section_base.SectionBase {
+    
+    constructor (section_name, ext, settings) {
+        super(section_name, ext, settings);
 
         this.actor.add_style_class_name('timer-section');
 
@@ -230,9 +228,9 @@ var SectionMain = new Lang.Class({
         this.sigm.connect(this.slider, 'value-changed', (slider, value) => this.slider_changed(slider, value));
         this.sigm.connect(this.slider, 'drag-end', () => this.slider_released());
         this.sigm.connect(this.slider.actor, 'scroll-event', () => this.slider_released());
-    },
+    }
 
-    disable_section: function () {
+    disable_section () {
         this.dbus_impl.unexport();
         this.stop();
         this._store_cache();
@@ -244,27 +242,27 @@ var SectionMain = new Lang.Class({
             this.fullscreen = null;
         }
 
-        this.parent();
-    },
+        super.disable_section();
+    }
 
-    _store_cache: function () {
+    _store_cache () {
         if (! this.cache_file.query_exists(null))
             this.cache_file.create(Gio.FileCreateFlags.NONE, null);
 
         this.cache_file.replace_contents(JSON.stringify(this.cache, null, 2),
             null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
-    },
+    }
 
-    toggle_timer: function () {
+    toggle_timer () {
         if      (this.timer_state === TimerState.STOPPED) this.start();
         else if (this.timer_state === TimerState.RUNNING) this.stop();
-    },
+    }
 
     // This func is used for DBus.
     // DBus has no optional arguments, so @time === 0 and @msg === "null" means
     // that those arguments are omitted, and in that case we don't update the
     // default preset.
-    start_from_default_preset: function (time, msg) {
+    start_from_default_preset (time, msg) {
         this.current_preset = this.cache.default_preset;
 
         if (time > 0)       this.current_preset.time = time;
@@ -273,9 +271,9 @@ var SectionMain = new Lang.Class({
         Mainloop.idle_add(() => this._store_cache());
 
         this.start(this.current_preset.time);
-    },
+    }
 
-    start_from_preset: function (preset, time = null) {
+    start_from_preset (preset, time = null) {
         this.current_preset = preset;
 
         if (time !== null) {
@@ -284,10 +282,10 @@ var SectionMain = new Lang.Class({
         }
 
         this.start(preset.time);
-    },
+    }
 
     // @time: int (seconds)
-    start: function (time) {
+    start (time) {
         this.timer_state = TimerState.RUNNING;
 
         if (this.tic_mainloop_id) {
@@ -313,9 +311,9 @@ var SectionMain = new Lang.Class({
             this.panel_item.set_mode('icon_text');
 
         this._tic();
-    },
+    }
 
-    stop: function () {
+    stop () {
         this.timer_state = TimerState.STOPPED;
 
         this.clock = this.end_time - GLib.get_monotonic_time();
@@ -332,9 +330,9 @@ var SectionMain = new Lang.Class({
 
         if (this.settings.get_enum('timer-panel-mode') === PanelMode.DYNAMIC)
             this.panel_item.set_mode('icon');
-    },
+    }
 
-    reset: function () {
+    reset () {
         this.timer_state = TimerState.OFF;
 
         if (this.tic_mainloop_id) {
@@ -350,15 +348,15 @@ var SectionMain = new Lang.Class({
 
         if (this.settings.get_enum('timer-panel-mode') === PanelMode.DYNAMIC)
             this.panel_item.set_mode('icon');
-    },
+    }
 
-    _on_timer_expired: function () {
+    _on_timer_expired () {
         this.reset();
         this._send_notif();
         this.dbus_impl.emit_signal('timer_expired', null);
-    },
+    }
 
-    _tic: function () {
+    _tic () {
         this.clock = this.end_time - GLib.get_monotonic_time();
 
         this._update_slider();
@@ -373,9 +371,9 @@ var SectionMain = new Lang.Class({
         this.tic_mainloop_id = Mainloop.timeout_add_seconds(1, () => {
             this._tic();
         });
-    },
+    }
 
-    _update_time_display: function () {
+    _update_time_display () {
         let time = Math.ceil(this.clock / 1000000);
         let txt;
 
@@ -399,20 +397,20 @@ var SectionMain = new Lang.Class({
         this.header_label.text = txt;
         this.panel_item.set_label(txt);
         this.fullscreen.set_banner_text(txt);
-    },
+    }
 
     // Update slider based on the clock.
     // This function is the inverse of the function that is used to calc the
     // clock based on the slider.
-    _update_slider: function () {
+    _update_slider () {
         let x = this.clock / TIMER_MAX_DURATION;
         let y = (Math.log(x * (Math.pow(2, 10) - 1) +1)) / Math.log(2) / 10;
 
         this.slider.setValue(y);
         this.fullscreen.slider.setValue(y);
-    },
+    }
 
-    slider_released: function () {
+    slider_released () {
         if (this.clock < 1000000) {
             this.reset();
         } else {
@@ -420,9 +418,9 @@ var SectionMain = new Lang.Class({
             this.start();
             this._store_cache();
         }
-    },
+    }
 
-    slider_changed: function (slider, value) {
+    slider_changed (slider, value) {
         if (this.tic_mainloop_id) {
             Mainloop.source_remove(this.tic_mainloop_id);
             this.tic_mainloop_id = null;
@@ -456,9 +454,9 @@ var SectionMain = new Lang.Class({
             this.clock = TIMER_MAX_DURATION;
             this._update_time_display();
         }
-    },
+    }
 
-    _send_notif: function () {
+    _send_notif () {
         let notif_type = this.settings.get_enum('timer-notif-style');
 
         if (notif_type === NotifStyle.NONE) {
@@ -496,9 +494,9 @@ var SectionMain = new Lang.Class({
             this.sound_player.set_sound_uri(this.settings.get_string('timer-sound-file-path'));
             this.sound_player.play(this.current_preset.repeat_sound);
         }
-    },
+    }
 
-    _show_presets: function () {
+    _show_presets () {
         let presets_view = new TimerPresetsView(this.ext, this);
 
         this.timepicker_container.add_actor(presets_view.actor);
@@ -544,9 +542,9 @@ var SectionMain = new Lang.Class({
             this.header.show();
             this.slider_item.show();
         });
-    },
+    }
 
-    show_fullscreen: function () {
+    show_fullscreen () {
         this.ext.menu.close();
 
         if (! this.fullscreen) {
@@ -555,9 +553,9 @@ var SectionMain = new Lang.Class({
         }
 
         this.fullscreen.open();
-    },
+    }
 
-    _toggle_panel_item_mode: function () {
+    _toggle_panel_item_mode () {
         switch (this.settings.get_enum('timer-panel-mode')) {
           case PanelMode.ICON:
             this.panel_item.set_mode('icon');
@@ -572,9 +570,9 @@ var SectionMain = new Lang.Class({
             if (this.timer_state === TimerState.RUNNING) this.panel_item.set_mode('icon_text');
             else                                         this.panel_item.set_mode('icon');
         }
-    },
+    }
 
-    highlight_tokens: function (text) {
+    highlight_tokens (text) {
         text = GLib.markup_escape_text(text, -1);
         text = MISC_UTILS.split_on_whitespace(text);
 
@@ -595,8 +593,8 @@ var SectionMain = new Lang.Class({
 
         text = text.join('');
         return MISC_UTILS.markdown_to_pango(text, this.ext.markdown_map);
-    },
-});
+    }
+}
 Signals.addSignalMethods(SectionMain.prototype);
 
 
@@ -614,10 +612,10 @@ Signals.addSignalMethods(SectionMain.prototype);
 //    - 'start-timer'   (returns a preset obj)
 //    - 'delete-preset' (returns a preset obj)
 // =====================================================================
-const TimerPresetsView = new Lang.Class({
-    Name: 'Timepp.TimerPresetsView',
+class TimerPresetsView {
+    
 
-    _init: function(ext, delegate) {
+    constructor(ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -702,9 +700,9 @@ const TimerPresetsView = new Lang.Class({
         this.entry.entry.clutter_text.connect('text-changed', () => this._search_presets());
         this.button_add_preset.connect('clicked', () => this._show_preset_editor());
         this.button_ok.connect('clicked', () => this.emit('ok'));
-    },
+    }
 
-    _search_presets: function () {
+    _search_presets () {
         this.preset_items_scrollbox.remove_all_children();
         let needle = this.entry.entry.get_text().toLowerCase();
 
@@ -724,9 +722,9 @@ const TimerPresetsView = new Lang.Class({
             for (let it of reduced_results)
                 this.preset_items_scrollbox.add_child(it[1].actor);
         }
-    },
+    }
 
-    _show_preset_editor: function (item) {
+    _show_preset_editor (item) {
         let preset       = item ? item.preset : null;
         let is_deletable = Boolean(preset) && !item.is_default;
 
@@ -793,9 +791,9 @@ const TimerPresetsView = new Lang.Class({
             this.entry.entry.grab_key_focus();
             editor.actor.destroy();
         });
-    },
+    }
 
-    _new_preset_item: function (preset) {
+    _new_preset_item (preset) {
         let item = {};
 
         item.preset = preset;
@@ -859,9 +857,9 @@ const TimerPresetsView = new Lang.Class({
 
 
         return item;
-    },
+    }
 
-    _on_preset_item_event: function (item, event) {
+    _on_preset_item_event (item, event) {
         switch (event.type()) {
             case Clutter.EventType.ENTER: {
                 let related = event.get_related();
@@ -903,8 +901,8 @@ const TimerPresetsView = new Lang.Class({
                 break;
             }
         }
-    },
-});
+    }
+}
 Signals.addSignalMethods(TimerPresetsView.prototype);
 
 
@@ -918,10 +916,10 @@ Signals.addSignalMethods(TimerPresetsView.prototype);
 //
 // @signals: 'ok', 'cancel', 'delete'
 // =====================================================================
-const TimerPresetEditor = new Lang.Class({
-    Name: 'Timepp.TimerPresetEditor',
+class TimerPresetEditor {
+    
 
-    _init: function(ext, delegate, preset, is_deletable) {
+    constructor(ext, delegate, preset, is_deletable) {
         this.ext      = ext;
         this.delegate = delegate;
         this.preset   = preset;
@@ -1027,24 +1025,24 @@ const TimerPresetEditor = new Lang.Class({
         this.checkbox_item.connect('button-press-event', () => {
             this.sound_checkbox.actor.checked = !this.sound_checkbox.actor.checked;
         });
-    },
+    }
 
-    _set_time: function () {
+    _set_time () {
         if (! this.preset) return;
 
         this.hr.set_counter(Math.floor(this.preset.time / 3600));
         this.min.set_counter(Math.floor(this.preset.time % 3600 / 60));
         if (this.sec) this.sec.set_counter(this.preset.time % 60);
-    },
+    }
 
-    _get_time: function () {
+    _get_time () {
         let h   = this.hr.counter * 3600;
         let min = this.min.counter * 60;
         let sec = this.sec ? this.sec.counter : 0;
 
         return h + min + sec;
-    },
-});
+    }
+}
 Signals.addSignalMethods(TimerPresetEditor.prototype);
 
 
@@ -1058,12 +1056,10 @@ Signals.addSignalMethods(TimerPresetEditor.prototype);
 //
 // @signals: 'monitor-changed'
 // =====================================================================
-const TimerFullscreen = new Lang.Class({
-    Name    : 'Timepp.TimerFullscreen',
-    Extends : FULLSCREEN.Fullscreen,
-
-    _init: function (ext, delegate, monitor) {
-        this.parent(monitor);
+class TimerFullscreen extends FULLSCREEN.Fullscreen {
+    
+    constructor (ext, delegate, monitor) {
+        super(monitor);
         this.default_style_class = this.actor.style_class;
 
         this.ext      = ext;
@@ -1154,9 +1150,9 @@ const TimerFullscreen = new Lang.Class({
                     return Clutter.EVENT_PROPAGATE;
             }
         });
-    },
+    }
 
-    close: function () {
+    close () {
         this.delegate.sound_player.stop();
 
         if (this.delegate.timer_state === TimerState.OFF) {
@@ -1166,29 +1162,29 @@ const TimerFullscreen = new Lang.Class({
                 this.delegate.settings.get_boolean('timer-show-seconds') ? '00:00:00' : '00:00');
         }
 
-        this.parent();
-    },
+        super.close();
+    }
 
-    on_timer_started: function () {
+    on_timer_started () {
         this.actor.style_class = this.default_style_class;
         this.title.text = '';
         this.start_pause_icon.icon_name   = 'timepp-pause-symbolic';
         this.start_pause_icon.style_class = 'pause-icon';
         this.start_pause_icon.show();
-    },
+    }
 
-    on_timer_stopped: function () {
+    on_timer_stopped () {
         this.actor.style_class = this.default_style_class + ' timer-stopped';
         this.start_pause_icon.icon_name = 'timepp-start-symbolic';
         this.start_pause_icon.style_class = 'start-icon';
-    },
+    }
 
-    on_timer_off: function () {
+    on_timer_off () {
         this.start_pause_icon.hide();
         this.slider.setValue(0);
-    },
+    }
 
-    on_timer_expired: function () {
+    on_timer_expired () {
         if (this.delegate.current_preset.msg) {
             this.title.text = TIMER_EXPIRED_MSG;
             this.set_banner_text(this.delegate.highlight_tokens(this.delegate.current_preset.msg));
@@ -1197,6 +1193,6 @@ const TimerFullscreen = new Lang.Class({
         }
 
         this.actor.style_class = this.default_style_class + ' timer-expired';
-    },
-});
+    }
+}
 Signals.addSignalMethods(TimerFullscreen.prototype);

--- a/sections/timer.js
+++ b/sections/timer.js
@@ -7,7 +7,7 @@ const Main        = imports.ui.main;
 const CheckBox    = imports.ui.checkBox;
 const MessageTray = imports.ui.messageTray;
 const Slider      = imports.ui.slider;
-
+const ByteArray = imports.byteArray;
 const Signals     = imports.signals;
 const Mainloop    = imports.mainloop;
 
@@ -71,7 +71,7 @@ const PanelMode = {
 // @ext      : obj (main extension object)
 // @settings : obj (extension settings)
 // =====================================================================
-class SectionMain extends ME.imports.sections.section_base.SectionBase {
+var SectionMain = class SectionMain extends ME.imports.sections.section_base.SectionBase {
     
     constructor (section_name, ext, settings) {
         super(section_name, ext, settings);
@@ -92,7 +92,7 @@ class SectionMain extends ME.imports.sections.section_base.SectionBase {
 
         {
             let [,xml,] = Gio.file_new_for_path(IFACE).load_contents(null);
-            xml = '' + xml;
+            xml = '' + ByteArray.toString(xml);
             this.dbus_impl = Gio.DBusExportedObject.wrapJSObject(xml, this);
             this.dbus_impl.export(Gio.DBus.session, '/timepp/zagortenay333/Timer');
         }
@@ -118,7 +118,7 @@ class SectionMain extends ME.imports.sections.section_base.SectionBase {
 
             if (this.cache_file.query_exists(null)) {
                 let [a, contents, b] = this.cache_file.load_contents(null);
-                this.cache = JSON.parse(contents);
+                this.cache = JSON.parse(ByteArray.toString(contents));
             }
 
             if (!this.cache || !this.cache.format_version ||
@@ -612,7 +612,7 @@ Signals.addSignalMethods(SectionMain.prototype);
 //    - 'start-timer'   (returns a preset obj)
 //    - 'delete-preset' (returns a preset obj)
 // =====================================================================
-class TimerPresetsView {
+var TimerPresetsView  = class TimerPresetsView {
     
 
     constructor(ext, delegate) {
@@ -916,7 +916,7 @@ Signals.addSignalMethods(TimerPresetsView.prototype);
 //
 // @signals: 'ok', 'cancel', 'delete'
 // =====================================================================
-class TimerPresetEditor {
+var TimerPresetEditor  = class TimerPresetEditor {
     
 
     constructor(ext, delegate, preset, is_deletable) {
@@ -1056,7 +1056,7 @@ Signals.addSignalMethods(TimerPresetEditor.prototype);
 //
 // @signals: 'monitor-changed'
 // =====================================================================
-class TimerFullscreen extends FULLSCREEN.Fullscreen {
+var TimerFullscreen = class TimerFullscreen extends FULLSCREEN.Fullscreen {
     
     constructor (ext, delegate, monitor) {
         super(monitor);

--- a/sections/todo/MAIN.js
+++ b/sections/todo/MAIN.js
@@ -59,7 +59,6 @@ class SectionMain extends ME.imports.sections.section_base.SectionBase {
     
     constructor (section_name, ext, settings) {
         super(section_name, ext, settings);
-
         this.actor.add_style_class_name('todo-section');
 
         this.separate_menu = this.settings.get_boolean('todo-separate-menu');
@@ -187,8 +186,7 @@ class SectionMain extends ME.imports.sections.section_base.SectionBase {
             if (t === '00:00') this._on_new_day_started();
         });
         this.sigm.connect(this.settings, 'changed::todo-panel-mode', () => this._toggle_panel_item_mode());
-        //this.sigm.connect(this.ext, 'custom-css-changed', () => this._on_custom_css_changed());
-
+        this.sigm.connect(this.ext, 'custom-css-changed', () => this._on_custom_css_changed());
 
         //
         // finally

--- a/sections/todo/MAIN.js
+++ b/sections/todo/MAIN.js
@@ -5,7 +5,7 @@ const GLib         = imports.gi.GLib;
 const Clutter      = imports.gi.Clutter;
 const GnomeDesktop = imports.gi.GnomeDesktop;
 const Main         = imports.ui.main;
-const Lang         = imports.lang;
+
 const Signals      = imports.signals;
 const Mainloop     = imports.mainloop;
 
@@ -187,7 +187,7 @@ class SectionMain extends ME.imports.sections.section_base.SectionBase {
             if (t === '00:00') this._on_new_day_started();
         });
         this.sigm.connect(this.settings, 'changed::todo-panel-mode', () => this._toggle_panel_item_mode());
-        this.sigm.connect(this.ext, 'custom-css-changed', () => this._on_custom_css_changed());
+        //this.sigm.connect(this.ext, 'custom-css-changed', () => this._on_custom_css_changed());
 
 
         //

--- a/sections/todo/MAIN.js
+++ b/sections/todo/MAIN.js
@@ -55,12 +55,10 @@ const CACHE_FILE = '~/.cache/timepp_gnome_shell_extension/timepp_todo.json';
 //   - 'new-day' (new day started) (returns string in yyyy-mm-dd iso format)
 //   - 'tasks-changed'
 // =====================================================================
-var SectionMain = new Lang.Class({
-    Name    : 'Timepp.Todo',
-    Extends : ME.imports.sections.section_base.SectionBase,
-
-    _init: function (section_name, ext, settings) {
-        this.parent(section_name, ext, settings);
+class SectionMain extends ME.imports.sections.section_base.SectionBase {
+    
+    constructor (section_name, ext, settings) {
+        super(section_name, ext, settings);
 
         this.actor.add_style_class_name('todo-section');
 
@@ -196,9 +194,9 @@ var SectionMain = new Lang.Class({
         // finally
         //
         this._init_todo_file();
-    },
+    }
 
-    disable_section: function () {
+    disable_section () {
         if (this.create_tasks_mainloop_id) {
             Mainloop.source_remove(this.create_tasks_mainloop_id);
             this.create_tasks_mainloop_id = null;
@@ -222,10 +220,10 @@ var SectionMain = new Lang.Class({
         this.view_manager      = null;
         this.tasks             = [];
 
-        this.parent();
-    },
+        super.disable_section();
+    }
 
-    _init_todo_file: function () {
+    _init_todo_file () {
         this.show_view__loading(true);
         this.view_manager.lock = true;
 
@@ -286,21 +284,21 @@ var SectionMain = new Lang.Class({
             this.on_tasks_changed(needs_write);
             this.time_tracker = new TIME_TRACKER.TimeTracker(this.ext, this);
         });
-    },
+    }
 
-    _disable_todo_file_monitor: function () {
+    _disable_todo_file_monitor () {
         if (this.todo_file_monitor) {
             this.todo_file_monitor.cancel();
             this.todo_file_monitor = null;
         }
-    },
+    }
 
-    _enable_todo_file_monitor: function () {
+    _enable_todo_file_monitor () {
         [this.todo_file_monitor,] =
             MISC_UTILS.file_monitor(this.todo_txt_file, () => this._on_todo_file_changed());
-    },
+    }
 
-    store_cache: function () {
+    store_cache () {
         if (! this.cache_file) return;
 
         if(! this.cache_file.query_exists(null))
@@ -308,9 +306,9 @@ var SectionMain = new Lang.Class({
 
         this.cache_file.replace_contents(JSON.stringify(this.cache, null, 2),
             null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
-    },
+    }
 
-    get_current_todo_file: function () {
+    get_current_todo_file () {
         if (this.current_todo_file) return this.current_todo_file;
 
         for (let it of this.cache.todo_files) {
@@ -321,9 +319,9 @@ var SectionMain = new Lang.Class({
         }
 
         return this.current_todo_file;
-    },
+    }
 
-    write_tasks_to_file: function () {
+    write_tasks_to_file () {
         this._disable_todo_file_monitor();
 
         let content = '';
@@ -333,18 +331,18 @@ var SectionMain = new Lang.Class({
             Gio.FileCreateFlags.REPLACE_DESTINATION, null);
 
         this._enable_todo_file_monitor();
-    },
+    }
 
-    _on_todo_file_changed: function (event_type) {
+    _on_todo_file_changed (event_type) {
         this._init_todo_file();
-    },
+    }
 
-    _on_new_day_started: function () {
+    _on_new_day_started () {
         this.emit('new-day', MISC_UTILS.date_yyyymmdd());
         if (this._check_dates()) this.on_tasks_changed(true, true);
-    },
+    }
 
-    _check_dates: function () {
+    _check_dates () {
         let today          = MISC_UTILS.date_yyyymmdd();
         let tasks_updated  = false;
         let recurred_tasks = 0;
@@ -379,19 +377,19 @@ var SectionMain = new Lang.Class({
         }
 
         return tasks_updated;
-    },
+    }
 
-    _on_custom_css_changed: function () {
+    _on_custom_css_changed () {
         for (let task of this.tasks) {
             task.update_body_markup();
             task.update_dates_markup();
         }
-    },
+    }
 
     // The maps have the structure:
     // @key : string  (a context/project/priority)
     // @val : natural (number of tasks that have that @key)
-    _reset_stats_obj: function () {
+    _reset_stats_obj () {
         this.stats = {
             deferred_tasks        : 0,
             recurring_completed   : 0,
@@ -403,16 +401,16 @@ var SectionMain = new Lang.Class({
             contexts              : new Map(),
             projects              : new Map(),
         };
-    },
+    }
 
-    _toggle_panel_item_mode: function () {
+    _toggle_panel_item_mode () {
         if (this.settings.get_enum('todo-panel-mode') === 0)
             this.panel_item.set_mode('icon');
         else if (this.settings.get_enum('todo-panel-mode') === 1)
             this.panel_item.set_mode('text');
         else
             this.panel_item.set_mode('icon_text');
-    },
+    }
 
     // Create task objects from the given task strings and add them to the
     // this.tasks array.
@@ -421,7 +419,7 @@ var SectionMain = new Lang.Class({
     //
     // @todo_strings : array (of strings; each string is a line in todo.txt file)
     // @callback     : func
-    create_tasks: function (todo_strings, callback) {
+    create_tasks (todo_strings, callback) {
         if (this.create_tasks_mainloop_id) {
             Mainloop.source_remove(this.create_tasks_mainloop_id);
             this.create_tasks_mainloop_id = null;
@@ -439,9 +437,9 @@ var SectionMain = new Lang.Class({
         this.create_tasks_mainloop_id = Mainloop.idle_add(() => {
             this._create_tasks__finish(0, todo_strings, callback);
         });
-    },
+    }
 
-    _create_tasks__finish: function (i, todo_strings, callback) {
+    _create_tasks__finish (i, todo_strings, callback) {
         if (i === todo_strings.length) {
             if (typeof(callback) === 'function') callback();
             this.create_tasks_mainloop_id = null;
@@ -458,9 +456,9 @@ var SectionMain = new Lang.Class({
         this.create_tasks_mainloop_id = Mainloop.idle_add(() => {
             this._create_tasks__finish(++i, todo_strings, callback);
         });
-    },
+    }
 
-    on_tasks_changed: function (write_to_file = true, refresh_default_view = false) {
+    on_tasks_changed (write_to_file = true, refresh_default_view = false) {
         //
         // Update stats obj
         //
@@ -564,9 +562,9 @@ var SectionMain = new Lang.Class({
         if (write_to_file) this.write_tasks_to_file();
 
         this.emit('tasks-changed');
-    },
+    }
 
-    sort_tasks: function () {
+    sort_tasks () {
         if (! this.get_current_todo_file().automatic_sort) return;
 
         let property_map = {
@@ -607,7 +605,7 @@ var SectionMain = new Lang.Class({
                 else                                       return +(x > y) || +(x === y) - 1;
             }
         });
-    },
+    }
 
     // Append the task strings of each given task to the current done.txt file.
     //
@@ -617,7 +615,7 @@ var SectionMain = new Lang.Class({
     // The task objects will not be changed.
     //
     // @tasks: array (of task objects)
-    archive_tasks: function (tasks) {
+    archive_tasks (tasks) {
         let content = '';
         let today   = MISC_UTILS.date_yyyymmdd();
 
@@ -641,9 +639,9 @@ var SectionMain = new Lang.Class({
 
             append_stream.write_all(content, null);
         } catch (e) { logError(e); }
-    },
+    }
 
-    show_view__default: function (unlock = false, force_refresh = false) {
+    show_view__default (unlock = false, force_refresh = false) {
         if (unlock) this.view_manager.lock = false;
         else if (this.view_manager.lock) return;
 
@@ -663,9 +661,9 @@ var SectionMain = new Lang.Class({
             focused_actor  : view.dummy_focus_actor,
             close_callback : () => view.close(),
         });
-    },
+    }
 
-    show_view__time_tracker_stats: function (task) {
+    show_view__time_tracker_stats (task) {
         if (! this.time_tracker) return;
 
         this.ext.menu.close();
@@ -688,9 +686,9 @@ var SectionMain = new Lang.Class({
                 this.stats_view.show_mode__single(d.getFullYear(), d.getMonth(), task.task_str, '()');
             }
         });
-    },
+    }
 
-    show_view__loading: function (unlock = false) {
+    show_view__loading (unlock = false) {
         if (unlock) this.view_manager.lock = false;
         else if (this.view_manager.lock) return;
 
@@ -709,11 +707,11 @@ var SectionMain = new Lang.Class({
                 view.close();
                 this.panel_item.icon.icon_name = 'timepp-todo-symbolic';
                 this._toggle_panel_item_mode();
-            },
+            }
         });
-    },
+    }
 
-    show_view__search: function (search_str = false, unlock = false) {
+    show_view__search (search_str = false, unlock = false) {
         if (unlock) this.view_manager.lock = false;
         else if (this.view_manager.lock) return;
 
@@ -730,9 +728,9 @@ var SectionMain = new Lang.Class({
         });
 
         if (search_str) view.search_entry.text = search_str;
-    },
+    }
 
-    show_view__kanban_switcher: function (unlock = false) {
+    show_view__kanban_switcher (unlock = false) {
         if (unlock) this.view_manager.lock = false;
         else if (this.view_manager.lock) return;
 
@@ -745,9 +743,9 @@ var SectionMain = new Lang.Class({
             focused_actor  : view.entry,
             close_callback : () => view.close(),
         });
-    },
+    }
 
-    show_view__clear_completed: function (unlock = false) {
+    show_view__clear_completed (unlock = false) {
         if (unlock) this.view_manager.lock = false;
         else if (this.view_manager.lock) return;
 
@@ -790,9 +788,9 @@ var SectionMain = new Lang.Class({
         view.connect('cancel', () => {
             this.show_view__default();
         });
-    },
+    }
 
-    show_view__file_switcher: function (unlock = false) {
+    show_view__file_switcher (unlock = false) {
         if (unlock) this.view_manager.lock = false;
         else if (this.view_manager.lock) return;
 
@@ -818,9 +816,9 @@ var SectionMain = new Lang.Class({
         view.connect('cancel', () => {
             this.show_view__default();
         });
-    },
+    }
 
-    show_view__sort: function (unlock = false) {
+    show_view__sort (unlock = false) {
         if (unlock) this.view_manager.lock = false;
         else if (this.view_manager.lock) return;
 
@@ -843,9 +841,9 @@ var SectionMain = new Lang.Class({
             this.store_cache();
             this.show_view__default();
         });
-    },
+    }
 
-    show_view__filters: function (unlock = false) {
+    show_view__filters (unlock = false) {
         if (unlock) this.view_manager.lock = false;
         else if (this.view_manager.lock) return;
 
@@ -864,9 +862,9 @@ var SectionMain = new Lang.Class({
             this.store_cache();
             this.show_view__default();
         });
-    },
+    }
 
-    show_view__task_editor: function (task, unlock = false) {
+    show_view__task_editor (task, unlock = false) {
         if (unlock) this.view_manager.lock = false;
         else if (this.view_manager.lock) return;
 
@@ -909,6 +907,6 @@ var SectionMain = new Lang.Class({
         view.connect('cancel', () => {
             this.show_view__default(true);
         });
-    },
-});
+    }
+}
 Signals.addSignalMethods(SectionMain.prototype);

--- a/sections/todo/MAIN.js
+++ b/sections/todo/MAIN.js
@@ -5,7 +5,7 @@ const GLib         = imports.gi.GLib;
 const Clutter      = imports.gi.Clutter;
 const GnomeDesktop = imports.gi.GnomeDesktop;
 const Main         = imports.ui.main;
-
+const ByteArray = imports.byteArray;
 const Signals      = imports.signals;
 const Mainloop     = imports.mainloop;
 
@@ -55,7 +55,7 @@ const CACHE_FILE = '~/.cache/timepp_gnome_shell_extension/timepp_todo.json';
 //   - 'new-day' (new day started) (returns string in yyyy-mm-dd iso format)
 //   - 'tasks-changed'
 // =====================================================================
-class SectionMain extends ME.imports.sections.section_base.SectionBase {
+var SectionMain = class SectionMain extends ME.imports.sections.section_base.SectionBase {
     
     constructor (section_name, ext, settings) {
         super(section_name, ext, settings);
@@ -88,7 +88,7 @@ class SectionMain extends ME.imports.sections.section_base.SectionBase {
 
             if (this.cache_file.query_exists(null)) {
                 let [, contents] = this.cache_file.load_contents(null);
-                this.cache = JSON.parse(contents);
+                this.cache = JSON.parse(ByteArray.toString(contents));
             }
 
             if (!this.cache || !this.cache.format_version ||
@@ -275,7 +275,7 @@ class SectionMain extends ME.imports.sections.section_base.SectionBase {
         }
 
         let [, lines] = this.todo_txt_file.load_contents(null);
-        lines = String(lines).split(/\r?\n/).filter((l) => /\S/.test(l));
+        lines = ByteArray.toString(lines).split(/\r?\n/).filter((l) => /\S/.test(l));
 
         this.create_tasks(lines, () => {
             let needs_write = this._check_dates();

--- a/sections/todo/MAIN.js
+++ b/sections/todo/MAIN.js
@@ -165,7 +165,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         // panel item
         //
         this.panel_item.actor.add_style_class_name('todo-panel-item');
-        this.panel_item.icon.icon_name = 'timepp-todo-symbolic';
+        this.panel_item.icon.gicon = MISC_UTILS.getIcon('timepp-todo-symbolic');
         this._toggle_panel_item_mode();
 
 
@@ -692,7 +692,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
 
         this.panel_item.set_mode('icon');
         this.panel_item.actor.remove_style_class_name('done');
-        this.panel_item.icon.icon_name = 'timepp-todo-loading-symbolic';
+        this.panel_item.icon.gicon = MISC_UTILS.getIcon('timepp-todo-loading-symbolic');
 
         let view = new VIEW_LOADING.ViewLoading(this.ext, this);
 
@@ -703,7 +703,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
             focused_actor  : view.loading_msg,
             close_callback : () => {
                 view.close();
-                this.panel_item.icon.icon_name = 'timepp-todo-symbolic';
+                this.panel_item.icon.gicon = MISC_UTILS.getIcon('timepp-todo-symbolic');
                 this._toggle_panel_item_mode();
             }
         });

--- a/sections/todo/task_item.js
+++ b/sections/todo/task_item.js
@@ -6,7 +6,7 @@ const Pango    = imports.gi.Pango;
 const Clutter  = imports.gi.Clutter;
 const Main     = imports.ui.main;
 const CheckBox = imports.ui.checkBox;
-const Lang     = imports.lang;
+
 const Signals  = imports.signals;
 const Mainloop = imports.mainloop;
 
@@ -51,7 +51,7 @@ let LAST_TIME_CLICKED    = 0; // for double click on task
 class TaskItem {
     
 
-    _init (ext, delegate, task_str, self_update = true) {
+    constructor (ext, delegate, task_str, self_update = true) {
         this.ext      = ext;
         this.delegate = delegate;
         this.task_str = task_str;

--- a/sections/todo/task_item.js
+++ b/sections/todo/task_item.js
@@ -48,7 +48,7 @@ let LAST_TIME_CLICKED    = 0; // for double click on task
 // the todo.txt file but must in case a task recurs. (E.g., when we load
 // tasks from the todo.txt file.)
 // =====================================================================
-class TaskItem {
+var TaskItem  = class TaskItem {
     
 
     constructor (ext, delegate, task_str, self_update = true) {

--- a/sections/todo/task_item.js
+++ b/sections/todo/task_item.js
@@ -422,7 +422,7 @@ var TaskItem  = class TaskItem {
                     this.actor.add_style_class_name('hidden-task');
                     let icon_incognito_bin = new St.Button({ can_focus: true });
                     this.header.insert_child_at_index(icon_incognito_bin, 0);
-                    icon_incognito_bin.add_actor(new St.Icon({ icon_name: 'timepp-hidden-symbolic' }));
+                    icon_incognito_bin.add_actor(new St.Icon({ gicon : MISC.getIcon('timepp-hidden-symbolic') }));
 
                     words.splice(i, 1); i--; len--;
                 }
@@ -759,16 +759,16 @@ var TaskItem  = class TaskItem {
         this.header_icon_box = new St.BoxLayout({ x_align: Clutter.ActorAlign.END, style_class: 'icon-box' });
         this.header.add(this.header_icon_box, {expand: true});
 
-        this.stat_icon = new St.Icon({ visible:false, reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-graph-symbolic' });
+        this.stat_icon = new St.Icon({ visible:false, reactive: true, can_focus: true, track_hover: true, gicon : MISC.getIcon('timepp-graph-symbolic') });
         this.header_icon_box.add_actor(this.stat_icon);
 
-        this.pin_icon = new St.Icon({ visible:false, reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-pin-symbolic', style_class: 'pin-icon' });
+        this.pin_icon = new St.Icon({ visible:false, reactive: true, can_focus: true, track_hover: true, gicon : MISC.getIcon('timepp-pin-symbolic'), style_class: 'pin-icon' });
         this.header_icon_box.add_actor(this.pin_icon);
 
-        this.edit_icon = new St.Icon({ visible:false, reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-edit-symbolic' });
+        this.edit_icon = new St.Icon({ visible:false, reactive: true, can_focus: true, track_hover: true, gicon : MISC.getIcon('timepp-edit-symbolic') });
         this.header_icon_box.add_actor(this.edit_icon);
 
-        this.tracker_icon = new St.Icon({ visible:false, reactive: true, can_focus: true, track_hover: true, icon_name: 'timepp-start-symbolic', style_class: 'tracker-start-icon' });
+        this.tracker_icon = new St.Icon({ visible:false, reactive: true, can_focus: true, track_hover: true, gicon : MISC.getIcon('timepp-start-symbolic'), style_class: 'tracker-start-icon' });
         this.header_icon_box.add_actor(this.tracker_icon);
 
         // @NOTE: Use connect_press here because we need to play well with dnd.
@@ -862,7 +862,7 @@ var TaskItem  = class TaskItem {
 
     _show_tracker_running_icon () {
         this._create_header_icons();
-        this.tracker_icon.icon_name   = 'timepp-pause-symbolic';
+        this.tracker_icon.gicon = MISC.getIcon('timepp-pause-symbolic');
         this.tracker_icon.style_class = 'tracker-pause-icon';
         this.tracker_icon.visible     = true;
     }
@@ -870,7 +870,7 @@ var TaskItem  = class TaskItem {
     _show_tracker_stopped_icon () {
         this.tracker_icon.visible     = this.edit_icon.visible;
         this.tracker_icon.style_class = 'tracker-start-icon';
-        this.tracker_icon.icon_name   = 'timepp-start-symbolic';
+        this.tracker_icon.gicon = MISC.getIcon('timepp-start-symbolic');
     }
 
     on_tracker_started () {

--- a/sections/todo/task_item.js
+++ b/sections/todo/task_item.js
@@ -48,10 +48,10 @@ let LAST_TIME_CLICKED    = 0; // for double click on task
 // the todo.txt file but must in case a task recurs. (E.g., when we load
 // tasks from the todo.txt file.)
 // =====================================================================
-var TaskItem = new Lang.Class({
-    Name: 'Timepp.TaskItem',
+class TaskItem {
+    
 
-    _init: function (ext, delegate, task_str, self_update = true) {
+    _init (ext, delegate, task_str, self_update = true) {
         this.ext      = ext;
         this.delegate = delegate;
         this.task_str = task_str;
@@ -60,7 +60,7 @@ var TaskItem = new Lang.Class({
         //
         // @NOTE
         // If a var needs to be resettable, add it to the reset_props() method
-        // instead of the _init() method.
+        // instead of the constructor() method.
         //
 
 
@@ -143,9 +143,9 @@ var TaskItem = new Lang.Class({
         this.msg.connect('leave-event', () => MISC.global_wrapper.display.set_cursor(Meta.Cursor.DEFAULT));
         this.actor.connect('event', (actor, event) => this._on_event(actor, event));
         this.completion_checkbox.connect('clicked', () => this.toggle_task());
-    },
+    }
 
-    reset: function (self_update, task_str, update_tracker = true) {
+    reset (self_update, task_str, update_tracker = true) {
         if (task_str) {
             if (update_tracker && this.delegate.time_tracker)
                 this.delegate.time_tracker.update_record_name(this.task_str, task_str);
@@ -162,9 +162,9 @@ var TaskItem = new Lang.Class({
             this.check_deferred_tasks();
             this.update_dates_markup();
         }
-    },
+    }
 
-    reset_props: function () {
+    reset_props () {
         this.actor.style_class = 'task-item';
 
         this.msg.text = '';
@@ -235,9 +235,9 @@ var TaskItem = new Lang.Class({
         this.link_indices       = [];
 
         this.hide_header_icons();
-    },
+    }
 
-    _parse_task_str: function () {
+    _parse_task_str () {
         // The 'header' is part of the task_str at the start that includes
         // the 'x' (checked) sign, the priority, and the completion/creation
         // dates.
@@ -442,9 +442,9 @@ var TaskItem = new Lang.Class({
 
         this.msg.clutter_text.set_markup(words);
         this.msg_text = this.msg.text;
-    },
+    }
 
-    check_deferred_tasks: function (today = MISC.date_yyyymmdd()) {
+    check_deferred_tasks (today = MISC.date_yyyymmdd()) {
         if (! this.defer_date) return false;
 
         this.creation_date = this.defer_date;
@@ -457,9 +457,9 @@ var TaskItem = new Lang.Class({
         let prev = this.is_deferred;
         this.is_deferred = false;
         return prev;
-    },
+    }
 
-    check_recurrence: function () {
+    check_recurrence () {
         if (! this.rec_str) return false;
 
         let [do_recur, next_rec] = this._get_recurrence_date();
@@ -491,7 +491,7 @@ var TaskItem = new Lang.Class({
         if (next_rec) this.rec_next = next_rec;
 
         return do_recur;
-    },
+    }
 
     // This function assumes that the creation/completion dates are either valid
     // or equal to '0000-00-00' and that if a particular type of recurrence
@@ -507,7 +507,7 @@ var TaskItem = new Lang.Class({
     // @next_recurrence can be an empty string, which indicates that the next
     // recurrence couldn't be computed. E.g., the task recurs n days after
     // completion but isn't completed.
-    _get_recurrence_date: function () {
+    _get_recurrence_date () {
         let res   = [false, '8999-99-99'];
         let today = MISC.date_yyyymmdd();
 
@@ -594,9 +594,9 @@ var TaskItem = new Lang.Class({
         }
 
         return res;
-    },
+    }
 
-    update_body_markup: function () {
+    update_body_markup () {
         this.msg.text = '';
 
         for (let it of this.context_indices) {
@@ -624,9 +624,9 @@ var TaskItem = new Lang.Class({
         markup     = MISC.markdown_to_pango(markup, this.ext.markdown_map);
 
         this.msg.clutter_text.set_markup(markup);
-    },
+    }
 
-    update_dates_markup: function () {
+    update_dates_markup () {
         //
         // set the custom (todo.txt extension) dates
         //
@@ -715,9 +715,9 @@ var TaskItem = new Lang.Class({
             this.base_date_labels.destroy();
             this.base_date_labels = null;
         }
-    },
+    }
 
-    toggle_task: function () {
+    toggle_task () {
         if (this.completed) {
             let words = this.task_str.split(' ');
 
@@ -750,10 +750,10 @@ var TaskItem = new Lang.Class({
         }
 
         Mainloop.timeout_add(0, () => this.delegate.on_tasks_changed(true, true));
-    },
+    }
 
      // @SPEED Lazy load the icons.
-    _create_header_icons: function () {
+    _create_header_icons () {
         if (this.header_icon_box) return;
 
         this.header_icon_box = new St.BoxLayout({ x_align: Clutter.ActorAlign.END, style_class: 'icon-box' });
@@ -787,9 +787,9 @@ var TaskItem = new Lang.Class({
         this.delegate.sigm.connect_press(this.tracker_icon, Clutter.BUTTON_PRIMARY, true, () => {
             this.delegate.time_tracker.toggle_tracking(this);
         });
-    },
+    }
 
-    show_header_icons: function () {
+    show_header_icons () {
         this._create_header_icons();
 
         if (!this.hidden && !this.completed)
@@ -802,9 +802,9 @@ var TaskItem = new Lang.Class({
                 this.stat_icon.show();
             }
         }
-    },
+    }
 
-    hide_header_icons: function () {
+    hide_header_icons () {
         if (! this.header_icon_box) return;
 
         if (this.tracker_icon.style_class === 'tracker-start-icon' && !this.pinned) {
@@ -821,9 +821,9 @@ var TaskItem = new Lang.Class({
             this.pin_icon.visible = this.pinned;
             this.tracker_icon.visible = this.tracker_icon.style_class !== 'tracker-start-icon';
         }
-    },
+    }
 
-    _on_pin_icon_clicked: function () {
+    _on_pin_icon_clicked () {
         this.pinned = (this.pinned === 1) ? 0 : 1;
         let old_task_str = this.task_str;
 
@@ -851,38 +851,38 @@ var TaskItem = new Lang.Class({
         if (this.delegate.view_manager.current_view_name !== G.View.SEARCH) {
             Mainloop.timeout_add(0, () => this.delegate.on_tasks_changed(true, true));
         }
-    },
+    }
 
-    _toggle_tracker_icon: function () {
+    _toggle_tracker_icon () {
         if (this.tracker_icon.style_class === 'tracker-start-icon')
             this._show_tracker_running_icon();
         else
             this._show_tracker_stopped_icon();
-    },
+    }
 
-    _show_tracker_running_icon: function () {
+    _show_tracker_running_icon () {
         this._create_header_icons();
         this.tracker_icon.icon_name   = 'timepp-pause-symbolic';
         this.tracker_icon.style_class = 'tracker-pause-icon';
         this.tracker_icon.visible     = true;
-    },
+    }
 
-    _show_tracker_stopped_icon: function () {
+    _show_tracker_stopped_icon () {
         this.tracker_icon.visible     = this.edit_icon.visible;
         this.tracker_icon.style_class = 'tracker-start-icon';
         this.tracker_icon.icon_name   = 'timepp-start-symbolic';
-    },
+    }
 
-    on_tracker_started: function () {
+    on_tracker_started () {
         this._show_tracker_running_icon();
-    },
+    }
 
-    on_tracker_stopped: function () {
+    on_tracker_stopped () {
         this._show_tracker_stopped_icon();
-    },
+    }
 
     // Return word under mouse cursor if it's a context or project, else null.
-    _find_keyword: function (event) {
+    _find_keyword (event) {
         let [x, y] = event.get_coords();
         [, x, y]   = this.msg.transform_stage_point(x, y);
         let pos    = this.msg.clutter_text.coords_to_position(x, y);
@@ -908,9 +908,9 @@ var TaskItem = new Lang.Class({
             return words[i];
         else
             return null;
-    },
+    }
 
-    _scroll_task_priority: function (direction) {
+    _scroll_task_priority (direction) {
         let prio = this.prio_label.text;
 
         if (prio) this.actor.remove_style_class_name(prio[1]);
@@ -939,13 +939,13 @@ var TaskItem = new Lang.Class({
         }
 
         this.finish_scrolling_priority = true;
-    },
+    }
 
-    _finish_scrolling_priority: function () {
+    _finish_scrolling_priority () {
         let t = this.prio_label.text;
         this.reset(true, this.new_str_for_prio(t ? t : '(_)'));
         this.delegate.on_tasks_changed(true, this.delegate.get_current_todo_file().automatic_sort);
-    },
+    }
 
     // A little utility func to generate a new task_str with a new property.
     // If the task is completed the 'pri:' extension will be updated/added.
@@ -953,7 +953,7 @@ var TaskItem = new Lang.Class({
     // @priority: string (prio str or '(_)' to mean 'no priority')
     //
     // returns task string with the updated priority.
-    new_str_for_prio: function (priority, task_str = this.task_str) {
+    new_str_for_prio (priority, task_str = this.task_str) {
         if (priority !== '(_)' && !REG.TODO_PRIO.test(priority)) return task_str;
 
         priority = priority === '(_)' ? '' : priority;
@@ -981,9 +981,9 @@ var TaskItem = new Lang.Class({
         }
 
         return task_str;
-    },
+    }
 
-    scroll_into_view: function () {
+    scroll_into_view () {
         if (! this.actor_scrollview) return;
 
         for (let i = 0; i < 2; i++) {
@@ -991,9 +991,9 @@ var TaskItem = new Lang.Class({
                 MISC.scroll_to_item(s, s.get_last_child(), this.actor, this.actor_parent, !!i);
             }
         }
-    },
+    }
 
-    _on_event: function (actor, event) {
+    _on_event (actor, event) {
         switch (event.type()) {
           case Clutter.EventType.ENTER: {
             let related = event.get_related();
@@ -1074,6 +1074,6 @@ var TaskItem = new Lang.Class({
             }
           } break;
         }
-    },
-});
+    }
+}
 Signals.addSignalMethods(TaskItem.prototype);

--- a/sections/todo/time_tracker.js
+++ b/sections/todo/time_tracker.js
@@ -33,7 +33,6 @@ const G = ME.imports.sections.todo.GLOBAL;
 // @delegate : obj (main section object)
 // =====================================================================
 class TimeTracker {
-    
 
     constructor (ext, delegate) {
         this.ext      = ext;

--- a/sections/todo/time_tracker.js
+++ b/sections/todo/time_tracker.js
@@ -32,10 +32,10 @@ const G = ME.imports.sections.todo.GLOBAL;
 // @ext      : obj (main extension object)
 // @delegate : obj (main section object)
 // =====================================================================
-var TimeTracker = new Lang.Class({
-    Name: 'Timepp.TimeTracker',
+class TimeTracker {
+    
 
-    _init: function (ext, delegate) {
+    _init (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -130,15 +130,15 @@ var TimeTracker = new Lang.Class({
         // finally
         //
         this._init_finish();
-    },
+    }
 
-    _init_finish: function () {
+    _init_finish () {
         this._init_tracker_dir();
         this._init_daily_csv_map();
         this._archive_yearly_csv_file();
-    },
+    }
 
-    _init_tracker_dir: function () {
+    _init_tracker_dir () {
         this._disable_file_monitors();
 
         if (! this.csv_dir) return;
@@ -171,9 +171,9 @@ var TimeTracker = new Lang.Class({
             logError(e);
             this.csv_dir = "";
         }
-    },
+    }
 
-    _init_daily_csv_map: function () {
+    _init_daily_csv_map () {
         if (! this.csv_dir) return;
 
         this.daily_csv_map.clear();
@@ -238,9 +238,9 @@ var TimeTracker = new Lang.Class({
                 }
             }
         }
-    },
+    }
 
-    _write_daily_csv_file: function () {
+    _write_daily_csv_file () {
         if (! this.csv_dir) return;
 
         let today    = MISC_UTILS.date_yyyymmdd();
@@ -259,10 +259,10 @@ var TimeTracker = new Lang.Class({
                 Gio.FileCreateFlags.REPLACE_DESTINATION, null);
         } catch (e) { logError(e); }
         this._enable_file_monitors();
-    },
+    }
 
     // @year: string
-    _archive_daily_csv_file: function (year = null) {
+    _archive_daily_csv_file (year = null) {
         if (! this.csv_dir) return;
 
         this._disable_file_monitors();
@@ -294,10 +294,10 @@ var TimeTracker = new Lang.Class({
             if (v.tracking) v.intervals = `${time_str}..${time_str}..`;
             else            v.intervals = '';
         }
-    },
+    }
 
     // Returns bool (true = we archived the yearly file)
-    _archive_yearly_csv_file: function () {
+    _archive_yearly_csv_file () {
         if (! this.csv_dir) return;
 
         let d = new Date();
@@ -312,9 +312,9 @@ var TimeTracker = new Lang.Class({
         }
 
         return false;
-    },
+    }
 
-    _enable_file_monitors: function () {
+    _enable_file_monitors () {
         [this.daily_csv_file_monitor,] = MISC_UTILS.file_monitor(this.daily_csv_file, () => {
             this._on_tracker_files_modified();
         });
@@ -326,9 +326,9 @@ var TimeTracker = new Lang.Class({
         [this.yearly_csv_dir_monitor,] = MISC_UTILS.file_monitor(this.yearly_csv_dir, () => {
             this._on_tracker_files_modified();
         });
-    },
+    }
 
-    _disable_file_monitors: function () {
+    _disable_file_monitors () {
         if (this.daily_csv_file_monitor) {
             this.daily_csv_file_monitor.cancel();
             this.daily_csv_file_monitor = null;
@@ -343,9 +343,9 @@ var TimeTracker = new Lang.Class({
             this.yearly_csv_dir_monitor.cancel();
             this.yearly_csv_dir_monitor = null;
         }
-    },
+    }
 
-    _tracker_tic: function (...args) {
+    _tracker_tic (...args) {
         let d        = new Date();
         let time     = GLib.get_monotonic_time();
         let time_str = "%02d:%02d:%02d".format(d.getHours(), d.getMinutes(), d.getSeconds());
@@ -367,9 +367,9 @@ var TimeTracker = new Lang.Class({
         this.tic_mainloop_id = Mainloop.timeout_add_seconds(1, () => {
             this._tracker_tic(seconds + 1);
         });
-    },
+    }
 
-    _on_new_day_started: function () {
+    _on_new_day_started () {
         if (! this.csv_dir) this._init_finish();
 
         this._archive_daily_csv_file();
@@ -378,9 +378,9 @@ var TimeTracker = new Lang.Class({
 
         // To ensure a fresh yearly csv file.
         if (yearly_file_was_archived) this._init_tracker_dir();
-    },
+    }
 
-    _on_tracker_files_modified: function () {
+    _on_tracker_files_modified () {
         this.stop_all_tracking(false);
 
         this.daily_csv_map.clear();
@@ -389,9 +389,9 @@ var TimeTracker = new Lang.Class({
         this.stats_unique_projects.clear();
 
         this._init_finish();
-    },
+    }
 
-    _parse_csv_line: function (line) {
+    _parse_csv_line (line) {
         let res           = [false];
         let field         = '';
         let inside_quotes = false;
@@ -439,9 +439,9 @@ var TimeTracker = new Lang.Class({
         res[4] = res[4].replace(/""/g, '"');
 
         return res;
-    },
+    }
 
-    _create_csv_line: function (date, time, type, val, intervals) {
+    _create_csv_line (date, time, type, val, intervals) {
         let h, m, s;
 
         {
@@ -480,20 +480,20 @@ var TimeTracker = new Lang.Class({
 
             intervals = non_zero_intervals.join('||');
 
-            return `${date}, ${h}:${m}:${s}, ${type}, "${val}", ${intervals}\n`;
+            return `${date} ${h}:${m}:${s} ${type} "${val}", ${intervals}\n`;
         } else {
-            return `${date}, ${h}:${m}:${s}, ${type}, "${val}"\n`;
+            return `${date} ${h}:${m}:${s} ${type} "${val}"\n`;
         }
-    },
+    }
 
-    toggle_tracking: function (task) {
+    toggle_tracking (task) {
         let val = this.daily_csv_map.get(task.task_str);
 
         if (val && val.tracking) this.stop_tracking(task);
         else                     this.start_tracking(task);
-    },
+    }
 
-    stop_all_tracking: function (do_write_daily_csv_file = true, close_intervals = true) {
+    stop_all_tracking (do_write_daily_csv_file = true, close_intervals = true) {
         if (! this.csv_dir) return;
 
         for (let [k, v] of this.daily_csv_map) {
@@ -502,25 +502,25 @@ var TimeTracker = new Lang.Class({
         }
 
         if (do_write_daily_csv_file) this._write_daily_csv_file();
-    },
+    }
 
-    start_tracking_by_id: function (id) {
+    start_tracking_by_id (id) {
         if (! this.csv_dir) return;
 
         for (let it of this.delegate.tasks) {
             if (it.tracker_id === id) this.start_tracking(it);
         }
-    },
+    }
 
-    stop_tracking_by_id: function (id) {
+    stop_tracking_by_id (id) {
         if (! this.csv_dir) return;
 
         for (let it of this.delegate.tasks) {
             if (it.tracker_id === id) this.stop_tracking(it);
         }
-    },
+    }
 
-    start_tracking: function (task) {
+    start_tracking (task) {
         if (! this.csv_dir) {
             Main.notify(_('To track time, select a dir for csv files in the settings.'));
             return;
@@ -587,9 +587,9 @@ var TimeTracker = new Lang.Class({
         }
 
         this.dbus_impl.emit_signal('started_tracking', GLib.Variant.new('(s)', [task.task_str]));
-    },
+    }
 
-    stop_tracking: function (task, do_write_daily_csv_file = true, close_intervals = true) {
+    stop_tracking (task, do_write_daily_csv_file = true, close_intervals = true) {
         if (!this.csv_dir) return;
 
         let val = this.daily_csv_map.get(task.task_str);
@@ -633,9 +633,9 @@ var TimeTracker = new Lang.Class({
         if (do_write_daily_csv_file) this._write_daily_csv_file();
 
         this.dbus_impl.emit_signal('stopped_tracking', GLib.Variant.new('(s)', [task.task_str]));
-    },
+    }
 
-    get_tracked_tasks: function () {
+    get_tracked_tasks () {
         let res = "";
 
         for (let [k, v] of this.daily_csv_map) {
@@ -643,9 +643,9 @@ var TimeTracker = new Lang.Class({
         }
 
         return res ? res : "none";
-    },
+    }
 
-    get_tracked_projects: function () {
+    get_tracked_projects () {
         let res = "";
 
         for (let [k, v] of this.daily_csv_map) {
@@ -653,11 +653,11 @@ var TimeTracker = new Lang.Class({
         }
 
         return res ? res : "none";
-    },
+    }
 
     // Swap the old_task_str with the new_task_str in the daily_csv_map only.
     // The time tracked on the old_task_str is copied over to the new_task_str.
-    update_record_name: function (old_task_str, new_task_str) {
+    update_record_name (old_task_str, new_task_str) {
         if (!this.csv_dir || this.daily_csv_map.get(new_task_str)) return;
 
         let val = this.daily_csv_map.get(old_task_str);
@@ -676,18 +676,18 @@ var TimeTracker = new Lang.Class({
         this.stats_data.clear();
 
         this._write_daily_csv_file();
-    },
+    }
 
-    get_csv_dir_path: function () {
+    get_csv_dir_path () {
         let d = this.delegate.get_current_todo_file();
         if (!d) return "";
         return d.time_tracker_dir;
-    },
+    }
 
     // NOTE: The returned values are cached, use for READ-ONLY!
     //
     // returns: [@stats_data, @stats_unique_tasks, @stats_unique_projects, oldest_date]
-    get_stats: function () {
+    get_stats () {
         if (! this.csv_dir) return null;
 
         let today = MISC_UTILS.date_yyyymmdd();
@@ -795,9 +795,9 @@ var TimeTracker = new Lang.Class({
         this.oldest_date = oldest_date;
 
         return [this.stats_data, this.stats_unique_tasks, this.stats_unique_projects, oldest_date];
-    },
+    }
 
-    close: function () {
+    close () {
         this.stop_all_tracking(true, false);
 
         if (this.daily_csv_file_monitor) {
@@ -823,6 +823,6 @@ var TimeTracker = new Lang.Class({
         this.stats_unique_tasks.clear();
         this.stats_unique_projects.clear();
         this.dbus_impl.unexport();
-    },
-});
+    }
+}
 Signals.addSignalMethods(TimeTracker.prototype);

--- a/sections/todo/time_tracker.js
+++ b/sections/todo/time_tracker.js
@@ -3,7 +3,7 @@ const GLib     = imports.gi.GLib;
 const Shell    = imports.gi.Shell;
 const Main     = imports.ui.main;
 const Util     = imports.misc.util;
-
+const ByteArray = imports.byteArray;
 const Signals  = imports.signals;
 const Mainloop = imports.mainloop;
 
@@ -32,7 +32,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 // @ext      : obj (main extension object)
 // @delegate : obj (main section object)
 // =====================================================================
-class TimeTracker {
+var TimeTracker  = class TimeTracker {
 
     constructor (ext, delegate) {
         this.ext      = ext;
@@ -41,7 +41,7 @@ class TimeTracker {
 
         {
             let [,xml,] = Gio.file_new_for_path(IFACE).load_contents(null);
-            xml = '' + xml;
+            xml = '' + ByteArray.toString(xml);
             this.dbus_impl = Gio.DBusExportedObject.wrapJSObject(xml, this);
             this.dbus_impl.export(Gio.DBus.session, '/timepp/zagortenay333/TimeTracker');
         }
@@ -180,7 +180,7 @@ class TimeTracker {
         let today = MISC_UTILS.date_yyyymmdd();
 
         let [, lines] = this.daily_csv_file.load_contents(null);
-        lines = String(lines).split(/\r?\n/).filter((l) => /\S/.test(l));
+        lines = ByteArray.toString(lines).split(/\r?\n/).filter((l) => /\S/.test(l));
 
         let do_write_daily_csv_file = false;
         let tasks_to_be_tracked = [];

--- a/sections/todo/time_tracker.js
+++ b/sections/todo/time_tracker.js
@@ -3,7 +3,7 @@ const GLib     = imports.gi.GLib;
 const Shell    = imports.gi.Shell;
 const Main     = imports.ui.main;
 const Util     = imports.misc.util;
-const Lang     = imports.lang;
+
 const Signals  = imports.signals;
 const Mainloop = imports.mainloop;
 
@@ -35,7 +35,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 class TimeTracker {
     
 
-    _init (ext, delegate) {
+    constructor (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 

--- a/sections/todo/view__clear_tasks.js
+++ b/sections/todo/view__clear_tasks.js
@@ -28,10 +28,10 @@ const G = ME.imports.sections.todo.GLOBAL;
 //   - 'archive-all' (delete and write to done.txt all completed tasks)
 //   - 'cancel'
 // =====================================================================
-var ViewClearTasks = new Lang.Class({
-    Name: 'Timepp.ViewClearTasks',
+class ViewClearTasks {
+    
 
-    _init: function (ext, delegate) {
+    _init (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -109,10 +109,10 @@ var ViewClearTasks = new Lang.Class({
             else
                 this.emit('archive-all');
         });
-    },
+    }
 
-    close: function () {
+    close () {
         this.actor.destroy();
-    },
-});
+    }
+}
 Signals.addSignalMethods(ViewClearTasks.prototype);

--- a/sections/todo/view__clear_tasks.js
+++ b/sections/todo/view__clear_tasks.js
@@ -28,7 +28,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 //   - 'archive-all' (delete and write to done.txt all completed tasks)
 //   - 'cancel'
 // =====================================================================
-class ViewClearTasks {
+var ViewClearTasks  = class ViewClearTasks {
     
 
     constructor (ext, delegate) {

--- a/sections/todo/view__clear_tasks.js
+++ b/sections/todo/view__clear_tasks.js
@@ -7,6 +7,7 @@ const Mainloop = imports.mainloop;
 
 
 const ME = imports.misc.extensionUtils.getCurrentExtension();
+const MISC_UTILS = ME.imports.lib.misc_utils;
 
 
 const Gettext  = imports.gettext.domain(ME.metadata['gettext-domain']);
@@ -52,7 +53,7 @@ var ViewClearTasks  = class ViewClearTasks {
             this.delete_all_item = new St.BoxLayout({ reactive: true, style_class: 'row delete-completed-tasks' });
             this.content_box.add_child(this.delete_all_item);
 
-            this.delete_all_item.add(new St.Icon ({ icon_name: 'timepp-radioactive-symbolic' }));
+            this.delete_all_item.add(new St.Icon ({ gicon : MISC_UTILS.getIcon('timepp-radioactive-symbolic') }));
             this.delete_all_item.add(new St.Label ({ text: _('Delete all completed tasks'), x_expand: true, y_align: Clutter.ActorAlign.CENTER }));
 
             this.delete_all_radiobutton = new St.Button({ style_class: 'radiobutton', toggle_mode: true, can_focus: true, y_align: St.Align.MIDDLE });

--- a/sections/todo/view__clear_tasks.js
+++ b/sections/todo/view__clear_tasks.js
@@ -1,7 +1,7 @@
 const St       = imports.gi.St;
 const Clutter  = imports.gi.Clutter;
 const Main     = imports.ui.main;
-const Lang     = imports.lang;
+
 const Signals  = imports.signals;
 const Mainloop = imports.mainloop;
 
@@ -31,7 +31,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 class ViewClearTasks {
     
 
-    _init (ext, delegate) {
+    constructor (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 

--- a/sections/todo/view__default.js
+++ b/sections/todo/view__default.js
@@ -33,10 +33,10 @@ const G = ME.imports.sections.todo.GLOBAL;
 // @ext      : obj (main extension object)
 // @delegate : obj (main section object)
 // =====================================================================
-var ViewDefault = new Lang.Class({
-    Name: 'Timepp.ViewDefault',
+class ViewDefault {
+    
 
-    _init: function (ext, delegate) {
+    _init (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -112,9 +112,9 @@ var ViewDefault = new Lang.Class({
         // finally
         //
         this._init_columns();
-    },
+    }
 
-    _init_columns: function () {
+    _init_columns () {
         let w = this.delegate.settings.get_int('todo-task-width') + 20;
 
         this._clear_kanban_columns();
@@ -144,9 +144,9 @@ var ViewDefault = new Lang.Class({
 
         if (this.kanban_columns.size === 1) this.delegate.actor.add_style_class_name('one-column');
         if (this.ext.menu.isOpen) this._add_tasks_to_menu();
-    },
+    }
 
-    _get_active_kanban_board: function () {
+    _get_active_kanban_board () {
         for (let it of this.delegate.tasks) {
             if (! it.kanban_boards) continue;
 
@@ -156,15 +156,15 @@ var ViewDefault = new Lang.Class({
         }
 
         return [false, null, null];
-    },
+    }
 
-    _clear_kanban_columns: function () {
+    _clear_kanban_columns () {
         this._remove_tasks_from_menu();
         for (let [,column] of this.kanban_columns) column.close();
         this.kanban_columns.clear();
-    },
+    }
 
-    _add_tasks_to_menu: function () {
+    _add_tasks_to_menu () {
         if (this.add_tasks_to_menu_mainloop_id) {
             Mainloop.source_remove(this.add_tasks_to_menu_mainloop_id);
             this.add_tasks_to_menu_mainloop_id = null;
@@ -185,9 +185,9 @@ var ViewDefault = new Lang.Class({
         }
 
         this._add_tasks_to_menu__finish(0, arr, false);
-    },
+    }
 
-    _add_tasks_to_menu__finish: function (i, arr, scrollbar_shown) {
+    _add_tasks_to_menu__finish (i, arr, scrollbar_shown) {
         let n = 50;
 
         for (let j = 0; j < n; j++, i++) {
@@ -228,9 +228,9 @@ var ViewDefault = new Lang.Class({
         this.add_tasks_to_menu_mainloop_id = Mainloop.idle_add(() => {
             this._add_tasks_to_menu__finish(i, arr, scrollbar_shown);
         });
-    },
+    }
 
-    _remove_tasks_from_menu: function () {
+    _remove_tasks_from_menu () {
         if (this.add_tasks_to_menu_mainloop_id) {
             Mainloop.source_remove(this.add_tasks_to_menu_mainloop_id);
             this.add_tasks_to_menu_mainloop_id = null;
@@ -245,7 +245,7 @@ var ViewDefault = new Lang.Class({
             task.actor_scrollview = null;
             task.owner            = null;
         }
-    },
+    }
 
     // If we only have one column, then we hide it's vertical scrollbar if it's
     // not needed since the extra space that gets allocated for it is ugly.
@@ -253,14 +253,14 @@ var ViewDefault = new Lang.Class({
     // With multiple columns, we get all sorts of little issues with respect to
     // dnd that require nasty hacks.
     // It's not worth it, so we set the scrollbar to AUTOMATIC.
-    update_scrollbars: function () {
+    update_scrollbars () {
         if (!this.ext.menu.isOpen || this.kanban_columns.size > 1) return;
 
         for (let [,col] of this.kanban_columns) {
             col.tasks_scroll.vscrollbar_policy = Gtk.PolicyType.NEVER;
             if (this.ext.needs_scrollbar()) col.tasks_scroll.vscrollbar_policy = Gtk.PolicyType.ALWAYS;
         }
-    },
+    }
 
     // @task: obj (a task object)
     //
@@ -270,7 +270,7 @@ var ViewDefault = new Lang.Class({
     //
     // If invert_filters is false, return true if at least one filter is matched.
     // If invert_filters is true,  return false if at least one filter is matched.
-    _filter_test: function (task) {
+    _filter_test (task) {
         let filters = this.delegate.get_current_todo_file().filters;
 
         if (task.pinned)                    return true;
@@ -312,9 +312,9 @@ var ViewDefault = new Lang.Class({
         }
 
         return filters.invert_filters;
-    },
+    }
 
-    _has_active_filters: function () {
+    _has_active_filters () {
         let filters = this.delegate.get_current_todo_file().filters;
 
         if (filters.deferred          ||
@@ -331,9 +331,9 @@ var ViewDefault = new Lang.Class({
         }
 
         return false;
-    },
+    }
 
-    _toggle_filters: function () {
+    _toggle_filters () {
         let filters = this.delegate.get_current_todo_file().filters;
 
         filters.invert_filters = !filters.invert_filters;
@@ -345,9 +345,9 @@ var ViewDefault = new Lang.Class({
         this._add_tasks_to_menu();
 
         this.delegate.store_cache();
-    },
+    }
 
-    toggle_automatic_sort: function () {
+    toggle_automatic_sort () {
         let state = !this.automatic_sort;
 
         if (state) {
@@ -363,14 +363,14 @@ var ViewDefault = new Lang.Class({
 
         this.delegate.store_cache();
         if (state) this.delegate.on_tasks_changed(true, true);
-    },
+    }
 
-    on_drag_end: function (old_parent, new_parent, column) {
+    on_drag_end (old_parent, new_parent, column) {
         this.update_kan_string(false);
         this.delegate.on_tasks_changed(true, true);
-    },
+    }
 
-    update_kan_string: function (write_to_file = true) {
+    update_kan_string (write_to_file = true) {
         let new_kanban_str = this.kanban_string.slice(0, this.kanban_string.indexOf('|'));
 
         for (let it of this.content_box.get_children()) {
@@ -384,9 +384,9 @@ var ViewDefault = new Lang.Class({
         this.kanban_string = new_kanban_str;
 
         if (write_to_file) this.delegate.write_tasks_to_file();
-    },
+    }
 
-    _get_column: function (task) {
+    _get_column (task) {
         for (let [name, column] of this.kanban_columns) {
             if (column.is_kitchen_sink) return column;
 
@@ -398,9 +398,9 @@ var ViewDefault = new Lang.Class({
         }
 
         return null;
-    },
+    }
 
-    horiz_scroll: function (event) {
+    horiz_scroll (event) {
         let direction = event.get_scroll_direction();
         let delta = 0;
 
@@ -414,15 +414,15 @@ var ViewDefault = new Lang.Class({
 
         let a = bar.get_adjustment();
         a.value += delta * a.stepIncrement;
-    },
+    }
 
-    close: function () {
+    close () {
         this.sigm.clear();
         this._clear_kanban_columns();
         this.actor.destroy();
         this.actor = null;
-    },
-});
+    }
+}
 Signals.addSignalMethods(ViewDefault.prototype);
 
 
@@ -436,10 +436,10 @@ Signals.addSignalMethods(ViewDefault.prototype);
 // @col_str      : string
 // @is_collapsed : bool
 // =====================================================================
-var KanbanColumn = new Lang.Class({
-    Name: 'Timepp.KanbanColumn',
+class KanbanColumn {
+    
 
-    _init: function (ext, delegate, owner, col_str, is_collapsed) {
+    _init (ext, delegate, owner, col_str, is_collapsed) {
         this.ext          = ext;
         this.delegate     = delegate;
         this.owner        = owner;
@@ -640,14 +640,14 @@ var KanbanColumn = new Lang.Class({
             this.is_collapsed = false;
             this.collapse(false);
         }
-    },
+    }
 
-    toggle_collapse: function () {
+    toggle_collapse () {
         if (this.is_collapsed) this.uncollapse();
         else                   this.collapse();
-    },
+    }
 
-    collapse: function (update_kan_string = true) {
+    collapse (update_kan_string = true) {
         if (this.is_collapsed) return;
         this.is_collapsed = true;
 
@@ -672,9 +672,9 @@ var KanbanColumn = new Lang.Class({
         });
 
         if (update_kan_string) this.owner.update_kan_string();
-    },
+    }
 
-    uncollapse: function () {
+    uncollapse () {
         if (! this.is_collapsed) return;
         this.is_collapsed = false;
 
@@ -696,9 +696,9 @@ var KanbanColumn = new Lang.Class({
         this.header.rotation_angle_z = 0;
 
         this.owner.update_kan_string();
-    },
+    }
 
-    set_title: function () {
+    set_title () {
         let markup = `<b>${this.tasks_scroll_content.get_n_children()}</b>   `;
 
         for (let i = 0; i < this.filters.length; i++) {
@@ -718,9 +718,9 @@ var KanbanColumn = new Lang.Class({
         }
 
         this.kanban_title.clutter_text.set_markup(markup.replace(/\\ /g, ' '));
-    },
+    }
 
-    _maybe_show_title: function (event) {
+    _maybe_show_title (event) {
         if (! this.title_visible) return;
 
         let related = event.get_related();
@@ -729,16 +729,16 @@ var KanbanColumn = new Lang.Class({
             this.kanban_title.show();
             this.delegate.panel_item.actor.grab_key_focus();
         }
-    },
+    }
 
-    _hide_title: function () {
+    _hide_title () {
         if (this.is_collapsed) return;
         this.kanban_title.hide();
         this.header_fn_btns.show();
         if (this.title_visible) this.header_fn_btns.get_first_child().grab_key_focus();
-    },
+    }
 
-    _on_maybe_drag: function (event) {
+    _on_maybe_drag (event) {
         if (this.owner.kanban_columns.size < 2) return Clutter.EVENT_STOP;
 
         switch (event.get_source()) {
@@ -749,10 +749,10 @@ var KanbanColumn = new Lang.Class({
           default:
             return Clutter.EVENT_STOP;
         }
-    },
+    }
 
     // A task got dropped
-    on_drag_end: function (old_parent, new_parent, task) {
+    on_drag_end (old_parent, new_parent, task) {
         task.hide_header_icons();
 
         if (old_parent === new_parent) {
@@ -785,11 +785,11 @@ var KanbanColumn = new Lang.Class({
 
         if (this.delegate.get_current_todo_file().automatic_sort)
             this._sort_task_in_column(task.actor_parent, task);
-    },
+    }
 
     // We don't want to refresh the entire view after the tasks have been
     // sorted; we only need to put the dragged task in the right position.
-    _sort_task_in_column: function (container, task) {
+    _sort_task_in_column (container, task) {
         let tasks  = this.delegate.tasks;
         let idx    = tasks.indexOf(task);
         let sorted = false;
@@ -808,9 +808,9 @@ var KanbanColumn = new Lang.Class({
             container.remove_child(task.actor);
             container.add_child(task.actor);
         }
-    },
+    }
 
-    _sort_task_in_arrays: function (task) {
+    _sort_task_in_arrays (task) {
         if (this.tasks_scroll_content.get_n_children() < 2) return;
 
         let above    = true;
@@ -837,7 +837,7 @@ var KanbanColumn = new Lang.Class({
                 }
             }
         }
-    },
+    }
 
     // When the user drags a task from one column to another:
     //   - remove all properties in the task (priority, context, proj) that
@@ -857,7 +857,7 @@ var KanbanColumn = new Lang.Class({
     //   @old_col            : column in which the task used to be in
     //   @new_col            : column into which the user dropped the task
     //   @destination_column : column in which the task ended up
-    _update_task_props: function (old_parent, new_parent, task) {
+    _update_task_props (old_parent, new_parent, task) {
         let old_col, new_col, idx_old, idx_new;
 
         let children = this.owner.content_box.get_children();
@@ -941,9 +941,9 @@ var KanbanColumn = new Lang.Class({
         else                destination_column = no_prio_col[0];
 
         return [old_col, new_col, destination_column];
-    },
+    }
 
-    handleDragOver: function (source, drag_actor, x, y, time) {
+    handleDragOver (source, drag_actor, x, y, time) {
         if (source.dnd_group !== G.DNDGroup.TASK) return DND.DragMotionResult.CONTINUE;
         if (source.item.actor_parent === this.tasks_scroll_content) return DND.DragMotionResult.CONTINUE;
 
@@ -952,10 +952,10 @@ var KanbanColumn = new Lang.Class({
         this.tasks_scroll_content.add_child(source.item.actor);
 
         return DND.DragMotionResult.MOVE_DROP;
-    },
+    }
 
-    close: function () {
+    close () {
         this.sigm.clear();
-    },
-});
+    }
+}
 Signals.addSignalMethods(KanbanColumn.prototype);

--- a/sections/todo/view__default.js
+++ b/sections/todo/view__default.js
@@ -3,7 +3,7 @@ const Gtk       = imports.gi.Gtk;
 const Shell     = imports.gi.Shell;
 const Clutter   = imports.gi.Clutter;
 const Main      = imports.ui.main;
-const Lang      = imports.lang;
+
 const Signals   = imports.signals;
 const Mainloop  = imports.mainloop;
 
@@ -36,7 +36,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 class ViewDefault {
     
 
-    _init (ext, delegate) {
+    constructor (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -439,7 +439,7 @@ Signals.addSignalMethods(ViewDefault.prototype);
 class KanbanColumn {
     
 
-    _init (ext, delegate, owner, col_str, is_collapsed) {
+    constructor (ext, delegate, owner, col_str, is_collapsed) {
         this.ext          = ext;
         this.delegate     = delegate;
         this.owner        = owner;
@@ -619,7 +619,7 @@ class KanbanColumn {
         });
         this.sigm.connect(this.header, 'leave-event', (_, event) => this._maybe_show_title(event));
         this.sigm.connect(this.header, 'enter-event', () => this._hide_title());
-        this.sigm.connect(this.ext, 'custom-css-changed', () => this.set_title());
+        //this.sigm.connect(this.ext, 'custom-css-changed', () => this.set_title());
         this.sigm.connect_release(this.add_task_button, Clutter.BUTTON_PRIMARY, true, () => this.delegate.show_view__task_editor());
         this.sigm.connect_release(this.collapse_icon, Clutter.BUTTON_PRIMARY, true, () => this.toggle_collapse());
         this.sigm.connect_release(this.kanban_icon, Clutter.BUTTON_PRIMARY, true, () => this.delegate.show_view__kanban_switcher());

--- a/sections/todo/view__default.js
+++ b/sections/todo/view__default.js
@@ -33,7 +33,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 // @ext      : obj (main extension object)
 // @delegate : obj (main section object)
 // =====================================================================
-class ViewDefault {
+var ViewDefault  = class ViewDefault {
     
 
     constructor (ext, delegate) {
@@ -436,7 +436,7 @@ Signals.addSignalMethods(ViewDefault.prototype);
 // @col_str      : string
 // @is_collapsed : bool
 // =====================================================================
-class KanbanColumn {
+var KanbanColumn  = class KanbanColumn {
 
     constructor (ext, delegate, owner, col_str, is_collapsed) {
         this.ext          = ext;

--- a/sections/todo/view__default.js
+++ b/sections/todo/view__default.js
@@ -337,9 +337,11 @@ var ViewDefault  = class ViewDefault {
         let filters = this.delegate.get_current_todo_file().filters;
 
         filters.invert_filters = !filters.invert_filters;
-        this.filter_icon.icon_name = filters.invert_filters ?
-                                     'timepp-filter-inverted-symbolic' :
-                                     'timepp-filter-symbolic';
+        this.filter_icon.gicon = MISC_UTILS.getIcon(
+                                    filters.invert_filters ?
+                                    'timepp-filter-inverted-symbolic' :
+                                    'timepp-filter-symbolic'
+                                )
 
         this.needs_filtering = true;
         this._add_tasks_to_menu();
@@ -506,7 +508,7 @@ var KanbanColumn  = class KanbanColumn {
         this.add_task_bin = new St.BoxLayout();
         this.add_task_button.add_actor(this.add_task_bin);
 
-        this.add_task_icon = new St.Icon({ icon_name: 'timepp-plus-symbolic', y_align: Clutter.ActorAlign.CENTER });
+        this.add_task_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-plus-symbolic'), y_align: Clutter.ActorAlign.CENTER });
         this.add_task_bin.add_actor(this.add_task_icon);
 
         this.add_task_label = new St.Label({ text: _('Add New Task...'), y_align: Clutter.ActorAlign.CENTER });
@@ -519,13 +521,13 @@ var KanbanColumn  = class KanbanColumn {
         this.icon_box = new St.BoxLayout({ x_align: Clutter.ActorAlign.END, style_class: 'icon-box' });
         this.header_fn_btns.add_child(this.icon_box);
 
-        this.collapse_icon = new St.Icon({ icon_name: 'timepp-column-collapse-symbolic', can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'collapse-icon' });
+        this.collapse_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-column-collapse-symbolic'), can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'collapse-icon' });
         this.icon_box.add_child(this.collapse_icon);
 
-        this.kanban_icon = new St.Icon({ icon_name: 'timepp-kanban-symbolic', can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'kanban-icon' });
+        this.kanban_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-kanban-symbolic'), can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'kanban-icon' });
         this.icon_box.add_child(this.kanban_icon);
 
-        this.clear_icon = new St.Icon({ icon_name: 'timepp-clear-symbolic', can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'clear-icon' });
+        this.clear_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-clear-symbolic'), can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'clear-icon' });
         this.icon_box.add_child(this.clear_icon);
         this.clear_icon.visible = this.delegate.stats.completed > 0;
 
@@ -536,22 +538,22 @@ var KanbanColumn  = class KanbanColumn {
         else                               this.filter_icon.remove_style_class_name('active');
 
         if (this.delegate.get_current_todo_file().filters.invert_filters)
-            this.filter_icon.icon_name = 'timepp-filter-inverted-symbolic';
+            this.filter_icon.gicon = MISC_UTILS.getIcon('timepp-filter-inverted-symbolic');
         else
-            this.filter_icon.icon_name = 'timepp-filter-symbolic';
+            this.filter_icon.gicon = MISC_UTILS.getIcon('timepp-filter-symbolic');
 
-        this.sort_icon = new St.Icon({ icon_name: 'timepp-sort-ascending-symbolic', can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'sort-icon' });
+        this.sort_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-sort-ascending-symbolic'), can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'sort-icon' });
         this.icon_box.add_child(this.sort_icon);
         if (this.owner.automatic_sort) this.sort_icon.add_style_class_name('active');
         else                           this.sort_icon.remove_style_class_name('active');
 
-        this.search_icon = new St.Icon({ icon_name: 'timepp-search-symbolic', can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'search-icon' });
+        this.search_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-search-symbolic'), can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'search-icon' });
         this.icon_box.add_child(this.search_icon);
 
-        this.file_switcher_icon = new St.Icon({ icon_name: 'timepp-file-symbolic', can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'file-switcher-icon' });
+        this.file_switcher_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-file-symbolic'), can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'file-switcher-icon' });
         this.icon_box.add_child(this.file_switcher_icon);
 
-        this.stats_icon = new St.Icon({ icon_name: 'timepp-graph-symbolic', can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'stats-icon' });
+        this.stats_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-graph-symbolic'), can_focus: true, reactive: true, track_hover: true, y_align: Clutter.ActorAlign.CENTER, style_class: 'stats-icon' });
         this.icon_box.add_child(this.stats_icon);
 
 
@@ -651,7 +653,7 @@ var KanbanColumn  = class KanbanColumn {
         this.is_collapsed = true;
 
         this.tasks_scroll.hide();
-        this.collapse_icon.icon_name = 'timepp-column-uncollapse-symbolic';
+        this.collapse_icon.gicon = MISC_UTILS.getIcon('timepp-column-uncollapse-symbolic');
         this.actor.add_style_class_name('collapsed');
         this.icon_box.remove_child(this.collapse_icon);
         this.header.insert_child_at_index(this.collapse_icon, 0);
@@ -686,7 +688,7 @@ var KanbanColumn  = class KanbanColumn {
         this.actor.set_height(-1);
         this.header.set_width(-1);
         this.header_wrapper.set_width(-1);
-        this.collapse_icon.icon_name = 'timepp-column-collapse-symbolic';
+        this.collapse_icon.gicon = MISC_UTILS.getIcon('timepp-column-collapse-symbolic');
         this.actor.remove_style_class_name('collapsed');
         this.header.remove_child(this.collapse_icon);
         this.icon_box.insert_child_at_index(this.collapse_icon, 0);

--- a/sections/todo/view__default.js
+++ b/sections/todo/view__default.js
@@ -437,7 +437,6 @@ Signals.addSignalMethods(ViewDefault.prototype);
 // @is_collapsed : bool
 // =====================================================================
 class KanbanColumn {
-    
 
     constructor (ext, delegate, owner, col_str, is_collapsed) {
         this.ext          = ext;
@@ -619,7 +618,7 @@ class KanbanColumn {
         });
         this.sigm.connect(this.header, 'leave-event', (_, event) => this._maybe_show_title(event));
         this.sigm.connect(this.header, 'enter-event', () => this._hide_title());
-        //this.sigm.connect(this.ext, 'custom-css-changed', () => this.set_title());
+        this.sigm.connect(this.ext, 'custom-css-changed', () => this.set_title());
         this.sigm.connect_release(this.add_task_button, Clutter.BUTTON_PRIMARY, true, () => this.delegate.show_view__task_editor());
         this.sigm.connect_release(this.collapse_icon, Clutter.BUTTON_PRIMARY, true, () => this.toggle_collapse());
         this.sigm.connect_release(this.kanban_icon, Clutter.BUTTON_PRIMARY, true, () => this.delegate.show_view__kanban_switcher());

--- a/sections/todo/view__file_switcher.js
+++ b/sections/todo/view__file_switcher.js
@@ -4,7 +4,7 @@ const GLib     = imports.gi.GLib;
 const Pango    = imports.gi.Pango;
 const Clutter  = imports.gi.Clutter;
 const Main     = imports.ui.main;
-const Lang     = imports.lang;
+
 const Signals  = imports.signals;
 const Mainloop = imports.mainloop;
 
@@ -39,7 +39,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 class ViewFileSwitcher {
     
 
-    _init (ext, delegate) {
+    constructor (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 

--- a/sections/todo/view__file_switcher.js
+++ b/sections/todo/view__file_switcher.js
@@ -36,7 +36,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 // @signals:
 //   - 'update'
 // =====================================================================
-class ViewFileSwitcher {
+var ViewFileSwitcher  = class ViewFileSwitcher {
     
 
     constructor (ext, delegate) {
@@ -359,7 +359,7 @@ Signals.addSignalMethods(ViewFileSwitcher.prototype);
 //
 // @signals: 'ok', 'cancel', 'delete'
 // =====================================================================
-class FileInfoEditor {
+var FileInfoEditor  = class FileInfoEditor {
     
 
     constructor(ext, delegate, file) {

--- a/sections/todo/view__file_switcher.js
+++ b/sections/todo/view__file_switcher.js
@@ -224,9 +224,9 @@ var ViewFileSwitcher  = class ViewFileSwitcher {
 
         item.icon_box = new St.BoxLayout({ style_class: 'icon-box' });
         item.header.add_child(item.icon_box);
-        item.check_icon = new St.Icon({ visible: false, track_hover: true, can_focus: true, reactive: true, icon_name: 'timepp-todo-symbolic', style_class: 'file-switcher-item-check-icon' });
+        item.check_icon = new St.Icon({ visible: false, track_hover: true, can_focus: true, reactive: true, gicon : MISC_UTILS.getIcon('timepp-todo-symbolic'), style_class: 'file-switcher-item-check-icon' });
         item.icon_box.add_child(item.check_icon);
-        let edit_icon = new St.Icon({ visible: false, track_hover: true, can_focus: true, reactive: true, icon_name: 'timepp-edit-symbolic' });
+        let edit_icon = new St.Icon({ visible: false, track_hover: true, can_focus: true, reactive: true, gicon : MISC_UTILS.getIcon('timepp-edit-symbolic') });
         item.icon_box.add_child(edit_icon);
 
         {
@@ -397,7 +397,7 @@ var FileInfoEditor  = class FileInfoEditor {
             this.todo_entry = new St.Entry({ hint_text: _('Todo file'), can_focus: true });
             row.add_actor(this.todo_entry);
 
-            this.todo_search_icon = new St.Icon({ track_hover: true, reactive: true, icon_name: 'timepp-search-symbolic' });
+            this.todo_search_icon = new St.Icon({ track_hover: true, reactive: true, gicon : MISC_UTILS.getIcon('timepp-search-symbolic') });
             this.todo_entry.set_secondary_icon(this.todo_search_icon);
 
             if (file) this.todo_entry.text = file.todo_file;
@@ -412,7 +412,7 @@ var FileInfoEditor  = class FileInfoEditor {
             this.done_entry = new St.Entry({ hint_text: hint, can_focus: true });
             row.add_actor(this.done_entry);
 
-            this.done_search_icon = new St.Icon({ track_hover: true, reactive: true, icon_name: 'timepp-search-symbolic' });
+            this.done_search_icon = new St.Icon({ track_hover: true, reactive: true, gicon : MISC_UTILS.getIcon('timepp-search-symbolic') });
             this.done_entry.set_secondary_icon(this.done_search_icon);
 
             if (file) this.done_entry.text = file.done_file;
@@ -427,7 +427,7 @@ var FileInfoEditor  = class FileInfoEditor {
             this.tracker_entry = new St.Entry({ hint_text: hint, can_focus: true });
             row.add_actor(this.tracker_entry);
 
-            this.tracker_search_icon = new St.Icon({ track_hover: true, reactive: true, icon_name: 'timepp-search-symbolic' });
+            this.tracker_search_icon = new St.Icon({ track_hover: true, reactive: true, gicon : MISC_UTILS.getIcon('timepp-search-symbolic') });
             this.tracker_entry.set_secondary_icon(this.tracker_search_icon);
 
             if (file) this.tracker_entry.text = file.time_tracker_dir;

--- a/sections/todo/view__file_switcher.js
+++ b/sections/todo/view__file_switcher.js
@@ -36,10 +36,10 @@ const G = ME.imports.sections.todo.GLOBAL;
 // @signals:
 //   - 'update'
 // =====================================================================
-var ViewFileSwitcher = new Lang.Class({
-    Name: 'Timepp.ViewFileSwitcher',
+class ViewFileSwitcher {
+    
 
-    _init: function (ext, delegate) {
+    _init (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -116,9 +116,9 @@ var ViewFileSwitcher = new Lang.Class({
         this.button_cancel.connect('clicked', () => this.emit('cancel'));
         this.button_ok.connect('clicked', () => this._on_file_selected());
         this.entry.clutter_text.connect('activate', () => this._select_first());
-    },
+    }
 
-    _search: function () {
+    _search () {
         this.file_items_scrollbox.remove_all_children();
         let needle = this.entry.get_text().toLowerCase();
 
@@ -139,9 +139,9 @@ var ViewFileSwitcher = new Lang.Class({
             for (let it of reduced_results)
                 this.file_items_scrollbox.add_child(it[1].actor);
         }
-    },
+    }
 
-    _show_file_editor: function (item) {
+    _show_file_editor (item) {
         if (this.file_info_editor) this.file_info_editor.close();
 
         this.file_info_editor = new FileInfoEditor(this.ext, this.delegate, item ? item.file : null);
@@ -206,9 +206,9 @@ var ViewFileSwitcher = new Lang.Class({
             this.file_info_editor.close();
             this.file_info_editor = null;
         });
-    },
+    }
 
-    _add_new_file_item: function (file) {
+    _add_new_file_item (file) {
         let item = {};
         this.file_items.add(item);
 
@@ -264,15 +264,15 @@ var ViewFileSwitcher = new Lang.Class({
 
 
         return item;
-    },
+    }
 
-    _select_first: function () {
+    _select_first () {
         let c = this.file_items_scrollbox.get_first_child();
         if (!c) return;
         this._on_file_selected(c._delegate.file);
-    },
+    }
 
-    _on_file_selected: function (file) {
+    _on_file_selected (file) {
         let files = [];
 
         for (let it of this.file_items) {
@@ -281,9 +281,9 @@ var ViewFileSwitcher = new Lang.Class({
         }
 
         this.emit('update', files);
-    },
+    }
 
-    highlight_tokens: function (text) {
+    highlight_tokens (text) {
         text = GLib.markup_escape_text(text, -1);
         text = MISC_UTILS.markdown_to_pango(text, this.ext.markdown_map);
         text = MISC_UTILS.split_on_whitespace(text);
@@ -301,9 +301,9 @@ var ViewFileSwitcher = new Lang.Class({
         }
 
         return text.join('');
-    },
+    }
 
-    _on_file_item_event: function (item, event) {
+    _on_file_item_event (item, event) {
         switch (event.type()) {
           case Clutter.EventType.ENTER: {
             let related = event.get_related();
@@ -338,14 +338,14 @@ var ViewFileSwitcher = new Lang.Class({
             });
           } break;
         }
-    },
+    }
 
-    close: function () {
+    close () {
         if (this.file_info_editor) this.file_info_editor.close();
         this.file_info_editor = null;
         this.actor.destroy();
-    },
-});
+    }
+}
 Signals.addSignalMethods(ViewFileSwitcher.prototype);
 
 
@@ -359,10 +359,10 @@ Signals.addSignalMethods(ViewFileSwitcher.prototype);
 //
 // @signals: 'ok', 'cancel', 'delete'
 // =====================================================================
-const FileInfoEditor = new Lang.Class({
-    Name: 'Timepp.FileInfoEditor',
+class FileInfoEditor {
+    
 
-    _init: function(ext, delegate, file) {
+    constructor(ext, delegate, file) {
         this.ext      = ext;
         this.delegate = delegate;
         this.file     = file;
@@ -487,9 +487,9 @@ const FileInfoEditor = new Lang.Class({
         this.button_cancel.connect('clicked', () => this.emit('cancel'));
         this.name_entry.clutter_text.connect('text-changed', () => this._update_ok_btn());
         this.todo_entry.clutter_text.connect('text-changed', () => this._update_ok_btn());
-    },
+    }
 
-    _on_ok_clicked: function () {
+    _on_ok_clicked () {
         let file = this.file;
 
         if (! file) file = G.TODO_RECORD();
@@ -501,9 +501,9 @@ const FileInfoEditor = new Lang.Class({
         file.automatic_sort   = file ? file.automatic_sort : true,
 
         this.emit('ok', file);
-    },
+    }
 
-    _update_ok_btn: function () {
+    _update_ok_btn () {
         if (!this.name_entry.text || !this.todo_entry.text) {
             this.button_ok.visible = false;
             return;
@@ -524,13 +524,13 @@ const FileInfoEditor = new Lang.Class({
         }
 
         this.button_ok.visible = true;
-    },
+    }
 
-    close: function () {
+    close () {
         if (this.todo_file_chooser_proc) this.todo_file_chooser_proc.force_exit();
         if (this.done_file_chooser_proc) this.done_file_chooser_proc.force_exit();
         if (this.tracker_file_chooser_proc) this.tracker_file_chooser_proc.force_exit();
         this.actor.destroy();
-    },
-});
+    }
+}
 Signals.addSignalMethods(FileInfoEditor.prototype);

--- a/sections/todo/view__filters.js
+++ b/sections/todo/view__filters.js
@@ -4,7 +4,7 @@ const Clutter   = imports.gi.Clutter;
 const Main      = imports.ui.main;
 const CheckBox  = imports.ui.checkBox;
 const PopupMenu = imports.ui.popupMenu;
-const Lang      = imports.lang;
+
 const Signals   = imports.signals;
 const Mainloop  = imports.mainloop;
 
@@ -36,7 +36,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 class ViewFilters {
     
 
-    _init (ext, delegate) {
+    constructor (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 

--- a/sections/todo/view__filters.js
+++ b/sections/todo/view__filters.js
@@ -33,10 +33,10 @@ const G = ME.imports.sections.todo.GLOBAL;
 // @signals:
 //  - 'filters-updated' returns new filters record
 // =====================================================================
-var ViewFilters = new Lang.Class({
-    Name: 'Timepp.ViewFilters',
+class ViewFilters {
+    
 
-    _init: function (ext, delegate) {
+    _init (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -247,9 +247,9 @@ var ViewFilters = new Lang.Class({
         this.invert_item.connect('button-press-event', () => this.invert_toggle.toggle());
         this.button_reset.connect('clicked', () => this._reset_all());
         this.button_ok.connect('clicked', () => this._on_ok_clicked());
-    },
+    }
 
-    _load_filters: function () {
+    _load_filters () {
         let filters = this.delegate.get_current_todo_file().filters;
 
         this.invert_toggle.setToggleState(filters.invert_filters);
@@ -332,9 +332,9 @@ var ViewFilters = new Lang.Class({
             this.context_filters_box,
             this.project_filters_box,
         ].forEach((it) => it.get_n_children() === 1 && it.hide());
-    },
+    }
 
-    _reset_all: function () {
+    _reset_all () {
         if (this.filter_register.completed)
             this.filter_register.completed.checkbox.actor.checked = false;
 
@@ -350,9 +350,9 @@ var ViewFilters = new Lang.Class({
             for (let i = 0; i < arr.length; i++)
                 arr[i].checkbox.actor.checked = false;
         });
-    },
+    }
 
-    _new_filter_item: function (is_checked, label, count, is_deletable, parent_box) {
+    _new_filter_item (is_checked, label, count, is_deletable, parent_box) {
         let item = {};
 
         item.actor = new St.BoxLayout({ reactive: true, style_class: 'row filter-window-item' });
@@ -386,9 +386,9 @@ var ViewFilters = new Lang.Class({
         item.checkbox.actor.connect('key-focus-in', () => MISC_UTILS.scroll_to_item(this.filter_sectors_scroll, this.filter_sectors_scroll_box, item.actor, parent_box));
 
         return item;
-    },
+    }
 
-    _delete_custom_item: function (item) {
+    _delete_custom_item (item) {
         if (item.checkbox.actor.has_key_focus || close_button.has_key_focus)
             this.entry.entry.grab_key_focus();
 
@@ -400,24 +400,24 @@ var ViewFilters = new Lang.Class({
                 return;
             }
         }
-    },
+    }
 
-    _add_separator: function (container) {
+    _add_separator (container) {
         let sep = new PopupMenu.PopupSeparatorMenuItem();
         sep.actor.add_style_class_name('timepp-separator');
         container.add_child(sep.actor);
-    },
+    }
 
-    _on_nand_toggle_clicked: function (toggle_actor) {
+    _on_nand_toggle_clicked (toggle_actor) {
         if (toggle_actor.state) {
             toggle_actor.setToggleState(false);
         } else {
             for (let toggle of this.nand_toggles) toggle.setToggleState(false);
             toggle_actor.setToggleState(true);
         }
-    },
+    }
 
-    _on_ok_clicked: function () {
+    _on_ok_clicked () {
         let filters = G.FILTER_RECORD();
 
         filters.invert_filters = this.invert_toggle.state;
@@ -449,11 +449,11 @@ var ViewFilters = new Lang.Class({
         }
 
         this.emit('filters-updated', filters);
-    },
+    }
 
-    close: function () {
+    close () {
         this.actor.destroy();
-    },
-});
+    }
+}
 Signals.addSignalMethods(ViewFilters.prototype);
 

--- a/sections/todo/view__filters.js
+++ b/sections/todo/view__filters.js
@@ -377,7 +377,7 @@ var ViewFilters  = class ViewFilters {
         if (is_deletable) {
             let close_button = new St.Button({ can_focus: true, style_class: 'close-icon' });
             item.actor.add_actor(close_button);
-            close_button.add_actor(new St.Icon({ icon_name: 'timepp-close-symbolic' }));
+            close_button.add_actor(new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-close-symbolic') }));
             close_button.connect('clicked', () => this._delete_custom_item(item));
             close_button.connect('key-focus-in', () => MISC_UTILS.scroll_to_item(this.filter_sectors_scroll, this.filter_sectors_scroll_box, item.actor, parent_box));
         }

--- a/sections/todo/view__filters.js
+++ b/sections/todo/view__filters.js
@@ -33,7 +33,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 // @signals:
 //  - 'filters-updated' returns new filters record
 // =====================================================================
-class ViewFilters {
+var ViewFilters  = class ViewFilters {
     
 
     constructor (ext, delegate) {

--- a/sections/todo/view__kanban_switcher.js
+++ b/sections/todo/view__kanban_switcher.js
@@ -33,7 +33,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 // @ext      : obj (main extension object)
 // @delegate : obj (main section object)
 // =====================================================================
-class KanbanSwitcher {
+var KanbanSwitcher  = class KanbanSwitcher {
     
 
     constructor (ext, delegate, task) {

--- a/sections/todo/view__kanban_switcher.js
+++ b/sections/todo/view__kanban_switcher.js
@@ -3,7 +3,7 @@ const Gtk      = imports.gi.Gtk;
 const Pango    = imports.gi.Pango;
 const Clutter  = imports.gi.Clutter;
 const Main     = imports.ui.main;
-const Lang     = imports.lang;
+
 const Signals  = imports.signals;
 const Mainloop = imports.mainloop;
 
@@ -36,7 +36,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 class KanbanSwitcher {
     
 
-    _init (ext, delegate, task) {
+    constructor (ext, delegate, task) {
         this.ext      = ext;
         this.delegate = delegate;
 

--- a/sections/todo/view__kanban_switcher.js
+++ b/sections/todo/view__kanban_switcher.js
@@ -33,10 +33,10 @@ const G = ME.imports.sections.todo.GLOBAL;
 // @ext      : obj (main extension object)
 // @delegate : obj (main section object)
 // =====================================================================
-var KanbanSwitcher = new Lang.Class({
-    Name: 'Timepp.KanbanSwitcher',
+class KanbanSwitcher {
+    
 
-    _init: function (ext, delegate, task) {
+    _init (ext, delegate, task) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -115,9 +115,9 @@ var KanbanSwitcher = new Lang.Class({
         // finally
         //
         this._init_items();
-    },
+    }
 
-    _init_items: function () {
+    _init_items () {
         for (let it of this.delegate.tasks) {
             if (! it.kanban_boards) continue;
             for (let str of it.kanban_boards) this._add_new_item(str, it);
@@ -141,9 +141,9 @@ var KanbanSwitcher = new Lang.Class({
                 '<span foreground="' + this.ext.custom_css['-timepp-link-color'][0] +
                 '"><u><b>' + label.text + '</b></u></span>');
         }
-    },
+    }
 
-    _add_new_item: function (kan_str, task) {
+    _add_new_item (kan_str, task) {
         let [name, rest, is_active] = this._parse_kan_str(kan_str);
 
         let item = {};
@@ -205,17 +205,17 @@ var KanbanSwitcher = new Lang.Class({
         });
         this.delegate.sigm.connect_release(edit_icon, Clutter.BUTTON_PRIMARY, true, () => this._on_edit_clicked(item));
         item.actor.connect('event', (_, event) => this._on_item_event(item, event));
-    },
+    }
 
-    _parse_kan_str: function (str) {
+    _parse_kan_str (str) {
         let is_active = str[4] === '*';
         let name      = str.slice((is_active ? 5 : 4), str.indexOf('|'));
         let rest      = str.slice(str.indexOf('|')+1);
 
         return [name, rest, is_active];
-    },
+    }
 
-    _on_kanban_selected: function (item) {
+    _on_kanban_selected (item) {
         if (this.active_kan === item) {
             this.delegate.show_view__default();
             return;
@@ -234,13 +234,13 @@ var KanbanSwitcher = new Lang.Class({
         }
 
         this.delegate.on_tasks_changed(true, true);
-    },
+    }
 
-    _on_edit_clicked: function (item) {
+    _on_edit_clicked (item) {
         this.delegate.show_view__task_editor(item.task);
-    },
+    }
 
-    _search: function () {
+    _search () {
         this.items_scrollbox.remove_all_children();
         let needle = this.entry.get_text().toLowerCase();
 
@@ -258,9 +258,9 @@ var KanbanSwitcher = new Lang.Class({
 
             for (let it of reduced_results) this.items_scrollbox.add_child(it[1].actor);
         }
-    },
+    }
 
-    _on_item_event: function (item, event) {
+    _on_item_event (item, event) {
         let event_type = event.type();
 
         if (event_type === Clutter.EventType.ENTER) {
@@ -291,13 +291,13 @@ var KanbanSwitcher = new Lang.Class({
                 }
             });
         }
-    },
+    }
 
-    close: function () {
+    close () {
         for (let it of this.kan_items) it.task = null;
         this.active_kan = null;
         this.kan_items.clear();
         this.actor.destroy();
-    },
-});
+  }
+}
 Signals.addSignalMethods(KanbanSwitcher.prototype);

--- a/sections/todo/view__kanban_switcher.js
+++ b/sections/todo/view__kanban_switcher.js
@@ -169,10 +169,10 @@ var KanbanSwitcher  = class KanbanSwitcher {
         item.icon_box = new St.BoxLayout({ style_class: 'icon-box' });
         item.header.add_child(item.icon_box);
 
-        item.check_icon = new St.Icon({ visible: false, track_hover: true, can_focus: true, reactive: true, icon_name: 'timepp-todo-symbolic', style_class: 'file-switcher-item-check-icon' });
+        item.check_icon = new St.Icon({ visible: false, track_hover: true, can_focus: true, reactive: true, gicon : MISC_UTILS.getIcon('timepp-todo-symbolic'), style_class: 'file-switcher-item-check-icon' });
         item.icon_box.add_child(item.check_icon);
 
-        let edit_icon = new St.Icon({ visible: false, track_hover: true, can_focus: true, reactive: true, icon_name: 'timepp-edit-symbolic' });
+        let edit_icon = new St.Icon({ visible: false, track_hover: true, can_focus: true, reactive: true, gicon : MISC_UTILS.getIcon('timepp-edit-symbolic') });
         item.icon_box.add_child(edit_icon);
 
         if (is_active && !this.active_kan) {

--- a/sections/todo/view__loading.js
+++ b/sections/todo/view__loading.js
@@ -1,6 +1,6 @@
 const St       = imports.gi.St;
 const Main     = imports.ui.main;
-const Lang     = imports.lang;
+
 const Signals  = imports.signals;
 const Mainloop = imports.mainloop;
 
@@ -22,7 +22,7 @@ const ngettext = Gettext.ngettext;
 class ViewLoading {
     
 
-    _init (ext, delegate) {
+    constructor (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 

--- a/sections/todo/view__loading.js
+++ b/sections/todo/view__loading.js
@@ -19,7 +19,7 @@ const ngettext = Gettext.ngettext;
 // @ext      : obj (main extension object)
 // @delegate : obj (main section object)
 // =====================================================================
-class ViewLoading {
+var ViewLoading  = class ViewLoading {
     
 
     constructor (ext, delegate) {

--- a/sections/todo/view__loading.js
+++ b/sections/todo/view__loading.js
@@ -19,10 +19,10 @@ const ngettext = Gettext.ngettext;
 // @ext      : obj (main extension object)
 // @delegate : obj (main section object)
 // =====================================================================
-var ViewLoading = new Lang.Class({
-    Name: 'Timepp.ViewLoading',
+class ViewLoading {
+    
 
-    _init: function (ext, delegate) {
+    _init (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -36,10 +36,10 @@ var ViewLoading = new Lang.Class({
 
         this.loading_msg = new St.Label({ text: _('Loading...'), style_class: 'loading-msg' });
         this.actor.add_child(this.loading_msg);
-    },
+    }
 
-    close: function () {
+    close () {
         this.actor.destroy();
-    },
-});
+    }
+}
 Signals.addSignalMethods(ViewLoading.prototype);

--- a/sections/todo/view__search.js
+++ b/sections/todo/view__search.js
@@ -30,7 +30,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 //
 // @signals:
 // =====================================================================
-class ViewSearch {
+var ViewSearch  = class ViewSearch {
     
 
     constructor (ext, delegate) {

--- a/sections/todo/view__search.js
+++ b/sections/todo/view__search.js
@@ -2,7 +2,7 @@ const St        = imports.gi.St;
 const Gtk       = imports.gi.Gtk;
 const Clutter   = imports.gi.Clutter;
 const Main      = imports.ui.main;
-const Lang      = imports.lang;
+
 const Signals   = imports.signals;
 const Mainloop  = imports.mainloop;
 
@@ -33,7 +33,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 class ViewSearch {
     
 
-    _init (ext, delegate) {
+    constructor (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 

--- a/sections/todo/view__search.js
+++ b/sections/todo/view__search.js
@@ -69,10 +69,10 @@ var ViewSearch  = class ViewSearch {
             box = new St.BoxLayout({ style_class: 'icon-box' });
             this.search_entry.set_secondary_icon(box);
 
-            this.add_filter_icon = new St.Icon({ visible: false, track_hover: true, reactive: true, icon_name: 'timepp-filter-add-symbolic' });
+            this.add_filter_icon = new St.Icon({ visible: false, track_hover: true, reactive: true, gicon : MISC_UTILS.getIcon('timepp-filter-add-symbolic') });
             box.add_child(this.add_filter_icon);
 
-            this.search_close_icon = new St.Icon({ track_hover: true, reactive: true, style_class: 'close-icon', icon_name: 'timepp-close-symbolic' });
+            this.search_close_icon = new St.Icon({ track_hover: true, reactive: true, style_class: 'close-icon', gicon : MISC_UTILS.getIcon('timepp-close-symbolic') });
             box.add_child(this.search_close_icon);
         }
 

--- a/sections/todo/view__search.js
+++ b/sections/todo/view__search.js
@@ -30,10 +30,10 @@ const G = ME.imports.sections.todo.GLOBAL;
 //
 // @signals:
 // =====================================================================
-var ViewSearch = new Lang.Class({
-    Name: 'Timepp.ViewSearch',
+class ViewSearch {
+    
 
-    _init: function (ext, delegate) {
+    _init (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -100,9 +100,9 @@ var ViewSearch = new Lang.Class({
         // finally
         //
         this._search();
-    },
+    }
 
-    _search: function () {
+    _search () {
         if (this.add_tasks_to_menu_mainloop_id) {
             Mainloop.source_remove(this.add_tasks_to_menu_mainloop_id);
             this.add_tasks_to_menu_mainloop_id = null;
@@ -146,9 +146,9 @@ var ViewSearch = new Lang.Class({
 
         this.search_dict.set(needle, this.tasks_viewport);
         this._add_tasks_to_menu();
-    },
+    }
 
-    _find_prev_search_results: function (pattern) {
+    _find_prev_search_results (pattern) {
         let res = '';
 
         for (let [old_patt,] of this.search_dict) {
@@ -159,9 +159,9 @@ var ViewSearch = new Lang.Class({
         if (pattern === res) return [false, this.search_dict.get(res)];
         else if (res)        return [true,  this.search_dict.get(res)];
         else                 return [true,  this.delegate.tasks];
-    },
+    }
 
-    _add_tasks_to_menu: function () {
+    _add_tasks_to_menu () {
         if (this.add_tasks_to_menu_mainloop_id) {
             Mainloop.source_remove(this.add_tasks_to_menu_mainloop_id);
             this.add_tasks_to_menu_mainloop_id = null;
@@ -172,9 +172,9 @@ var ViewSearch = new Lang.Class({
         this.add_tasks_to_menu_mainloop_id = Mainloop.timeout_add(0, () => {
            this._add_tasks_to_menu__finish(0, false);
         });
-    },
+    }
 
-    _add_tasks_to_menu__finish: function (i, scrollbar_shown) {
+    _add_tasks_to_menu__finish (i, scrollbar_shown) {
         if (!scrollbar_shown && this.ext.needs_scrollbar()) {
             this.tasks_scroll.vscrollbar_policy = Gtk.PolicyType.ALWAYS;
             scrollbar_shown = true;
@@ -200,9 +200,9 @@ var ViewSearch = new Lang.Class({
         this.add_tasks_to_menu_mainloop_id = Mainloop.idle_add(() => {
             this._add_tasks_to_menu__finish(i, scrollbar_shown);
         });
-    },
+    }
 
-    _remove_tasks_from_menu: function () {
+    _remove_tasks_from_menu () {
         if (this.add_tasks_to_menu_mainloop_id) {
             Mainloop.source_remove(this.add_tasks_to_menu_mainloop_id);
             this.add_tasks_to_menu_mainloop_id = null;
@@ -215,9 +215,9 @@ var ViewSearch = new Lang.Class({
 
         this.tasks_scroll_content.remove_all_children();
         this.tasks_viewport = [];
-    },
+    }
 
-    _add_custom_filter: function () {
+    _add_custom_filter () {
         let needle  = this.search_entry.get_text();
         let filters = this.delegate.get_current_todo_file().filters;
 
@@ -227,12 +227,12 @@ var ViewSearch = new Lang.Class({
         filters.custom_active.push(needle);
         this.delegate.store_cache();
         this.delegate.show_view__default();
-    },
+    }
 
-    close: function () {
+    close () {
         this.search_dict.clear();
         this._remove_tasks_from_menu();
         this.actor.destroy();
-    },
-});
+    }
+}
 Signals.addSignalMethods(ViewSearch.prototype);

--- a/sections/todo/view__sort.js
+++ b/sections/todo/view__sort.js
@@ -32,7 +32,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 //
 // @signals: 'update-sort'
 // =====================================================================
-class ViewSort {
+var ViewSort  = class ViewSort {
     
 
     constructor (ext, delegate) {
@@ -152,7 +152,7 @@ Signals.addSignalMethods(ViewSort.prototype);
 //
 // @signals:
 // =====================================================================
-class SortItem{
+var SortItem = class SortItem{
     
 
     constructor (delegate, actor_scrollview, actor_parent, label, sort_type, sort_order) {

--- a/sections/todo/view__sort.js
+++ b/sections/todo/view__sort.js
@@ -32,10 +32,10 @@ const G = ME.imports.sections.todo.GLOBAL;
 //
 // @signals: 'update-sort'
 // =====================================================================
-var ViewSort = new Lang.Class({
-    Name: 'Timepp.ViewSort',
+class ViewSort {
+    
 
-    _init: function (ext, delegate) {
+    _init (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -123,25 +123,25 @@ var ViewSort = new Lang.Class({
         this.button_ok.connect('clicked', () => this._on_ok_clicked());
         this.toggle_automatic_sort_btn.connect('clicked', () => this._on_toggle_clicked());
         this.toggle_automatic_sort.connect('button-press-event', () => this._on_toggle_clicked());
-    },
+    }
 
-    _on_ok_clicked: function () {
+    _on_ok_clicked () {
         let res = [];
 
         for (let it of this.sort_items_box.get_children())
             res.push([it._owner.sort_type, it._owner.sort_order]);
 
         this.emit('update-sort', res, this.toggle.state);
-    },
+    }
 
-    _on_toggle_clicked: function () {
+    _on_toggle_clicked () {
         this.toggle.setToggleState(!this.toggle.state);
-    },
+    }
 
-    close: function () {
+    close () {
         this.actor.destroy();
-    },
-});
+    }
+}
 Signals.addSignalMethods(ViewSort.prototype);
 
 
@@ -152,10 +152,10 @@ Signals.addSignalMethods(ViewSort.prototype);
 //
 // @signals:
 // =====================================================================
-let SortItem = new Lang.Class({
-    Name: 'Timepp.SortItem',
+class SortItem{
+    
 
-    _init: function (delegate, actor_scrollview, actor_parent, label, sort_type, sort_order) {
+    _init (delegate, actor_scrollview, actor_parent, label, sort_type, sort_order) {
         this.delegate         = delegate;
         this.actor_scrollview = [[actor_scrollview], []];
         this.actor_parent     = actor_parent;
@@ -231,5 +231,5 @@ let SortItem = new Lang.Class({
 
             return Clutter.EVENT_PROPAGATE;
         });
-    },
-});
+    }
+}

--- a/sections/todo/view__sort.js
+++ b/sections/todo/view__sort.js
@@ -4,7 +4,7 @@ const Meta      = imports.gi.Meta;
 const Clutter   = imports.gi.Clutter;
 const Main      = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
-const Lang      = imports.lang;
+
 const Signals   = imports.signals;
 const Mainloop  = imports.mainloop;
 
@@ -35,7 +35,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 class ViewSort {
     
 
-    _init (ext, delegate) {
+    constructor (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -155,7 +155,7 @@ Signals.addSignalMethods(ViewSort.prototype);
 class SortItem{
     
 
-    _init (delegate, actor_scrollview, actor_parent, label, sort_type, sort_order) {
+    constructor (delegate, actor_scrollview, actor_parent, label, sort_type, sort_order) {
         this.delegate         = delegate;
         this.actor_scrollview = [[actor_scrollview], []];
         this.actor_parent     = actor_parent;

--- a/sections/todo/view__sort.js
+++ b/sections/todo/view__sort.js
@@ -179,10 +179,12 @@ var SortItem = class SortItem{
         this.sort_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true });
         this.icn_box.add_actor(this.sort_icon);
 
-        this.sort_icon.set_icon_name(
-            sort_order === G.SortOrder.ASCENDING ?
-            'timepp-sort-ascending-symbolic'   :
-            'timepp-sort-descending-symbolic'
+        this.sort_icon.set_gicon(
+            MISC.getIcon(
+                sort_order === G.SortOrder.ASCENDING ?
+                'timepp-sort-ascending-symbolic'   :
+                'timepp-sort-descending-symbolic'
+            )
         );
 
 
@@ -204,10 +206,10 @@ var SortItem = class SortItem{
         this.delegate.sigm.connect_press(this.sort_icon, Clutter.BUTTON_PRIMARY, true, () => {
             if (this.sort_order === G.SortOrder.ASCENDING) {
                 this.sort_order = G.SortOrder.DESCENDING;
-                this.sort_icon.icon_name = 'timepp-sort-descending-symbolic';
+                this.sort_icon.gicon = MISC.getIcon('timepp-sort-descending-symbolic');
             } else {
                 this.sort_order = G.SortOrder.ASCENDING;
-                this.sort_icon.icon_name = 'timepp-sort-ascending-symbolic';
+                this.sort_icon.gicon = MISC.getIcon('timepp-sort-ascending-symbolic');
             }
         });
         this.sort_icon.connect('key-press-event', (_, event) => {

--- a/sections/todo/view__stats.js
+++ b/sections/todo/view__stats.js
@@ -51,12 +51,10 @@ const StatsMode = {
 // @delegate : obj (main section object)
 // @monitor  : int (monitor position)
 // =====================================================================
-var StatsView = new Lang.Class({
-    Name    : 'Timepp.StatsView',
-    Extends : FULLSCREEN.Fullscreen,
-
-    _init: function (ext, delegate, monitor) {
-        this.parent(monitor);
+class StatsView extends FULLSCREEN.Fullscreen{
+    
+    constructor (ext, delegate, monitor) {
+        super(monitor);
 
         this.ext      = ext;
         this.delegate = delegate;
@@ -434,9 +432,9 @@ var StatsView = new Lang.Class({
         this.type_btn.connect('clicked', () => this.type_menu.toggle());
         this.ext.connect('custom-css-changed', () => this._on_custom_css_updated());
         this.date_picker.connect('date-changed', (_, ...args) => this._on_date_picker_changed(...args));
-    },
+    }
 
-    set_stats: function (stats_data, stats_unique_tasks, stats_unique_projects, oldest_date) {
+    set_stats (stats_data, stats_unique_tasks, stats_unique_projects, oldest_date) {
         this.stats_data            = stats_data;
         this.stats_unique_tasks    = Array.from(stats_unique_tasks);
         this.stats_unique_projects = Array.from(stats_unique_projects);
@@ -448,10 +446,10 @@ var StatsView = new Lang.Class({
         this.bound_date_2.set_range(oldest_date, today);
 
         this._update_string_date_map();
-    },
+    }
 
     // @date: string
-    show_mode__global: function (date) {
+    show_mode__global (date) {
         let actors = [
             this.inner_middle_box,
             this.vbars_graph.actor,
@@ -505,13 +503,13 @@ var StatsView = new Lang.Class({
             64,
             (vbar, interval_idx) => this._tooltip_format(vbar, interval_idx)
         );
-    },
+    }
 
     // @year  : int
     // @month : int (0-indexed)
     // @label : string (a project or task)
     // @type  : string ('()' or '++');
-    show_mode__single: function (year, month, label, type) {
+    show_mode__single (year, month, label, type) {
         let actors = [
             this.inner_middle_box,
             this.stats_card,
@@ -638,11 +636,11 @@ var StatsView = new Lang.Class({
         }
 
         this.stats_card_stats.clutter_text.set_markup(`<tt>${markup}</tt>`);
-    },
+    }
 
     // @label : string (description of range)
     // @range : array  (of the form [date_str_1, date_str_2])
-    show_mode__hot: function (label, range) {
+    show_mode__hot (label, range) {
         let actors = [
             this.inner_middle_box,
             this.vbars_graph.actor,
@@ -752,9 +750,9 @@ var StatsView = new Lang.Class({
         this.vbars_graph.draw_vbars(vbars, 8, 64, (vbar) => {
             return this._tooltip_format_hot_mode(vbar, n_days_in_range);
         });
-    },
+    }
 
-    show_mode__search: function () {
+    show_mode__search () {
         let actors = [this.entry, this.search_results_container];
 
         this._set_mode(StatsMode.SEARCH, null, () => {
@@ -774,9 +772,9 @@ var StatsView = new Lang.Class({
         this.top_box.layout_manager.homogeneous = true; // centers the entry
         this.nav_bar.get_children().forEach((it) => it.checked = false);
         Mainloop.idle_add(() => this.entry.grab_key_focus());
-    },
+    }
 
-    show_mode__banner: function (text) {
+    show_mode__banner (text) {
         this._set_mode(StatsMode.BANNER, null, () => {
             this.set_banner_size(0);
             this.nav_bar.show();
@@ -785,7 +783,7 @@ var StatsView = new Lang.Class({
         this.nav_bar.hide();
         this.set_banner_size(.2);
         this.set_banner_text(text);
-    },
+    }
 
     // A very simple way of handling different 'modes' (views) of the stats
     // interface.
@@ -802,7 +800,7 @@ var StatsView = new Lang.Class({
     // @mode_name     : string (use StatsMode enum only)
     // @args          : array  (of the args passed to a 'show_mode__' func)
     // @hide_callback : func   (used to close the prev mode)
-    _set_mode: function (name, args, hide_callback) {
+    _set_mode (name, args, hide_callback) {
         this.prev_mode = this.current_mode;
 
         this.current_mode = {
@@ -819,9 +817,9 @@ var StatsView = new Lang.Class({
             this.prev_mode.hide_callback();
             Mainloop.idle_add(() => focused_actor.grab_key_focus());
         }
-    },
+    }
 
-    _get_stats__heatmap: function (label) {
+    _get_stats__heatmap (label) {
         let res = {
             matrix      : [[], [], [], [], [], [], []],
             matrix_size : [7, 0],
@@ -905,9 +903,9 @@ var StatsView = new Lang.Class({
         res.matrix_size[1] = col;
 
         return res;
-    },
+    }
 
-    _get_stats__sum: function (keyword) {
+    _get_stats__sum (keyword) {
         let sum = {
             today        : [0, 0],
             week         : [0, 0],
@@ -965,9 +963,9 @@ var StatsView = new Lang.Class({
         });
 
         return sum;
-    },
+    }
 
-    _get_stats__vbars_hot: function (lower_bound, upper_bound) {
+    _get_stats__vbars_hot (lower_bound, upper_bound) {
         let stats = [];
 
         let hot_mode_type = this.delegate.settings.get_enum('todo-hot-mode-type');
@@ -1022,9 +1020,9 @@ var StatsView = new Lang.Class({
         }
 
         return vbars;
-    },
+    }
 
-    _get_stats__vbars_single: function (year, month, label, type) {
+    _get_stats__vbars_single (year, month, label, type) {
         month++; // make it 1-indexed
 
         let show_intervals = this.delegate.settings.get_boolean('todo-graph-shows-intervals');
@@ -1092,9 +1090,9 @@ var StatsView = new Lang.Class({
         }
 
         return vbars;
-    },
+    }
 
-    _get_stats__vbars_global: function (date) {
+    _get_stats__vbars_global (date) {
         let vbars   = [];
         let records = this.stats_data.get(date);
 
@@ -1133,9 +1131,9 @@ var StatsView = new Lang.Class({
         }
 
         return vbars;
-    },
+    }
 
-    _interval_stoa: function (interval_str) {
+    _interval_stoa (interval_str) {
         let res = [];
 
         for (let interval of interval_str.split('||')) {
@@ -1149,9 +1147,9 @@ var StatsView = new Lang.Class({
         }
 
         return res;
-    },
+    }
 
-    _tooltip_format_hot_mode: function (vbar, n_days_in_range) {
+    _tooltip_format_hot_mode (vbar, n_days_in_range) {
         let total_time_str = '%dh %dmin %ds'.format(
             Math.floor(vbar.info.total_time / 3600),
             Math.floor(vbar.info.total_time % 3600 / 60),
@@ -1183,10 +1181,10 @@ var StatsView = new Lang.Class({
                `- ${avg_excluding_off_days}\n\n` +
                `- ${avg_including_off_days}\n\n` +
                `${vbar.info.label.replace(/\\n/g, '\n')}`;
-    },
+    }
 
     // used in single and global modes
-    _tooltip_format: function (vbar, interval_idx) {
+    _tooltip_format (vbar, interval_idx) {
         let txt = '';
 
         txt += '- ' + _('Total') + ': %dh %dmin %ds'.format(
@@ -1229,9 +1227,9 @@ var StatsView = new Lang.Class({
         txt += '\n\n' + vbar.info.label.replace(/\\n/g, '\n');
 
         return txt;
-    },
+    }
 
-    _toggle_show_intervals: function () {
+    _toggle_show_intervals () {
         let current = this.delegate.settings.get_boolean('todo-graph-shows-intervals');
 
         if (current) {
@@ -1244,9 +1242,9 @@ var StatsView = new Lang.Class({
 
         if (this.current_mode.name === StatsMode.GLOBAL || this.current_mode.name === StatsMode.SINGLE)
             this.mode_func_map[this.current_mode.name](...this.current_mode.args);
-    },
+    }
 
-    _toggle_heatmap: function () {
+    _toggle_heatmap () {
         if (this.current_mode.name !== StatsMode.GLOBAL &&
             this.current_mode.name !== StatsMode.SINGLE)
             return;
@@ -1270,10 +1268,10 @@ var StatsView = new Lang.Class({
 
             this.heatmap_graph.draw_heatmap(params);
         }
-    },
+    }
 
     // @key_symbol: a clutter key symbol
-    _maybe_navigate_search_results: function (key_symbol) {
+    _maybe_navigate_search_results (key_symbol) {
         if (!this.task_results.box.visible && !this.project_results.box.visible)
             return;
 
@@ -1300,9 +1298,9 @@ var StatsView = new Lang.Class({
         else                                      parents = [this.project_results.scrollview, this.project_results.scrollbox];
 
         MISC_UTILS.scroll_to_item(parents[0], parents[1], new_selected);
-    },
+    }
 
-    _search: function () {
+    _search () {
         this.task_results.scrollbox.destroy_all_children();
         this.project_results.scrollbox.destroy_all_children();
         this.task_results.box.hide();
@@ -1402,17 +1400,17 @@ var StatsView = new Lang.Class({
                 type        : item.type,
             };
         }
-    },
+    }
 
-    _on_date_picker_changed: function (new_date_arr, new_date_str, old_date_arr, old_date_str) {
+    _on_date_picker_changed (new_date_arr, new_date_str, old_date_arr, old_date_str) {
         if (this.current_mode.name === StatsMode.GLOBAL) {
             this.show_mode__global(new_date_str);
         } else if (this.current_mode.name === StatsMode.SINGLE) {
             this.show_mode__single(new_date_arr[0], new_date_arr[1], this.current_mode.args[2], this.current_mode.args[3]);
         }
-    },
+    }
 
-    _update_heatmap_selected_square: function (date) {
+    _update_heatmap_selected_square (date) {
         let m = this.heatmap_graph.params.matrix;
         let square, d;
 
@@ -1431,9 +1429,9 @@ var StatsView = new Lang.Class({
                 }
             }
         }
-    },
+    }
 
-    _update_string_date_map: function () {
+    _update_string_date_map () {
         let today  = MISC_UTILS.date_yyyymmdd();
         let [oldest, ] = this.date_picker.get_range();
         let date_o = new Date(today + 'T00:00:00');
@@ -1454,9 +1452,9 @@ var StatsView = new Lang.Class({
 
         date_o.setMonth(date_o.getMonth() - 3);
         this.string_date_map.get('six_months')[1] = [MISC_UTILS.date_yyyymmdd(date_o), today];
-    },
+    }
 
-    _on_heatmap_clicked: function (square_label) {
+    _on_heatmap_clicked (square_label) {
         let [date, time] = square_label.split(' ');
 
         if (this.current_mode.name === StatsMode.GLOBAL) {
@@ -1470,9 +1468,9 @@ var StatsView = new Lang.Class({
 
             this.show_mode__single(...this.current_mode.args);
         }
-    },
+    }
 
-    _on_custom_css_updated: function () {
+    _on_custom_css_updated () {
         this.vbars_graph.draw_coord_system({
             axes_rgba     : this.custom_css['-timepp-axes-color'][1],
             y_label_rgba  : this.custom_css['-timepp-y-label-color'][1],
@@ -1483,9 +1481,9 @@ var StatsView = new Lang.Class({
 
         if (this.current_mode.name)
             this.mode_func_map[this.current_mode.name](...this.current_mode.args);
-    },
+    }
 
-    _on_new_day_started: function (today) {
+    _on_new_day_started (today) {
         let [lower,] = this.date_picker.get_range();
 
         this.date_picker.set_range(lower,  today);
@@ -1493,24 +1491,24 @@ var StatsView = new Lang.Class({
         this.bound_date_2.set_range(lower, today);
 
         this._update_string_date_map();
-    },
+    }
 
-    close: function () {
+    close () {
         this.stats_data            = null;
         this.stats_unique_tasks    = null;
         this.stats_unique_projects = null;
 
         this._set_mode('', null, null);
 
-        this.parent();
-    },
+        super.close();
+    }
 
-    destroy: function () {
+    destroy () {
         if (this.new_day_sig_id) this.delegate.disconnect(this.new_day_sig_id);
 
         this.type_menu.destroy();
         this.range_menu.destroy();
 
-        this.parent();
-    },
-});
+        super.destroy();
+    }
+}

--- a/sections/todo/view__stats.js
+++ b/sections/todo/view__stats.js
@@ -131,7 +131,13 @@ var StatsView = class StatsView extends FULLSCREEN.Fullscreen{
         //
         this.graph_interval_icon = new St.Button({ visible: false, y_align: St.Align.MIDDLE, can_focus: true, style_class: 'graph-interval-icon' });
         this.top_box_left.insert_child_at_index(this.graph_interval_icon, 0);
-        this.graph_interval_icon.add_actor(new St.Icon({ icon_name: this.delegate.settings.get_boolean('todo-graph-shows-intervals') ? 'timepp-graph-intervals-symbolic' : 'timepp-graph-symbolic' }));
+        this.graph_interval_icon.add_actor(new St.Icon({ gicon:
+            MISC_UTILS.getIcon(
+                this.delegate.settings.get_boolean('todo-graph-shows-intervals') ?
+                'timepp-graph-intervals-symbolic' :
+                'timepp-graph-symbolic'
+            )
+        }));
 
 
         //
@@ -139,7 +145,7 @@ var StatsView = class StatsView extends FULLSCREEN.Fullscreen{
         //
         this.heatmap_icon = new St.Button({ checked: this.delegate.settings.get_boolean('todo-stats-heatmap-visible'), visible: false, y_align: St.Align.MIDDLE, can_focus: true, style_class: 'heatmap-icon' });
         this.top_box_left.insert_child_at_index(this.heatmap_icon, 0);
-        this.heatmap_icon.add_actor(new St.Icon({ icon_name: 'timepp-heatmap-symbolic' }));
+        this.heatmap_icon.add_actor(new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-heatmap-symbolic') }));
 
 
         //
@@ -150,15 +156,15 @@ var StatsView = class StatsView extends FULLSCREEN.Fullscreen{
 
         this.single_mode_icon = new St.Button({ y_align: St.Align.MIDDLE, can_focus: true });
         this.nav_bar.add_actor(this.single_mode_icon);
-        this.single_mode_icon.add_actor(new St.Icon({ icon_name: 'timepp-search-symbolic' }));
+        this.single_mode_icon.add_actor(new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-search-symbolic') }));
 
         this.global_mode_icon = new St.Button({ y_align: St.Align.MIDDLE, can_focus: true });
         this.nav_bar.add_actor(this.global_mode_icon);
-        this.global_mode_icon.add_actor(new St.Icon({ icon_name: 'timepp-home-symbolic' }));
+        this.global_mode_icon.add_actor(new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-home-symbolic') }));
 
         this.hot_mode_icon = new St.Button({ y_align: St.Align.MIDDLE, can_focus: true });
         this.nav_bar.add_actor(this.hot_mode_icon);
-        this.hot_mode_icon.add_actor(new St.Icon({ icon_name: 'timepp-fire-symbolic' }));
+        this.hot_mode_icon.add_actor(new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-fire-symbolic') }));
 
 
         //
@@ -166,7 +172,7 @@ var StatsView = class StatsView extends FULLSCREEN.Fullscreen{
         //
         this.entry = new St.Entry({ can_focus: true, y_align: Clutter.ActorAlign.CENTER, visible: false, hint_text: _('Search...') });
         this.top_box_center.add_actor(this.entry);
-        this.entry.set_primary_icon(new St.Icon({ icon_name: 'timepp-search-symbolic' }));
+        this.entry.set_primary_icon(new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-search-symbolic') }));
 
         this.search_results_container = new St.BoxLayout({ visible: false, x_align: Clutter.ActorAlign.CENTER, x_expand: true, y_expand: true, style_class: 'search-results-box' });
         this.middle_box.add_actor(this.search_results_container);
@@ -1233,10 +1239,10 @@ var StatsView = class StatsView extends FULLSCREEN.Fullscreen{
         let current = this.delegate.settings.get_boolean('todo-graph-shows-intervals');
 
         if (current) {
-            this.graph_interval_icon.get_first_child().icon_name = 'timepp-graph-symbolic';
+            this.graph_interval_icon.get_first_child().gicon = MISC_UTILS.getIcon('timepp-graph-symbolic');
             this.delegate.settings.set_boolean('todo-graph-shows-intervals', false);
         } else {
-            this.graph_interval_icon.get_first_child().icon_name = 'timepp-graph-intervals-symbolic';
+            this.graph_interval_icon.get_first_child().gicon = MISC_UTILS.getIcon('timepp-graph-intervals-symbolic');
             this.delegate.settings.set_boolean('todo-graph-shows-intervals', true);
         }
 

--- a/sections/todo/view__stats.js
+++ b/sections/todo/view__stats.js
@@ -430,7 +430,7 @@ class StatsView extends FULLSCREEN.Fullscreen{
         this.graph_interval_icon.connect('clicked', () => this._toggle_show_intervals());
         this.range_btn.connect('clicked', () => this.range_menu.toggle());
         this.type_btn.connect('clicked', () => this.type_menu.toggle());
-        //this.ext.connect('custom-css-changed', () => this._on_custom_css_updated());
+        this.ext.connect('custom-css-changed', () => this._on_custom_css_updated());
         this.date_picker.connect('date-changed', (_, ...args) => this._on_date_picker_changed(...args));
     }
 

--- a/sections/todo/view__stats.js
+++ b/sections/todo/view__stats.js
@@ -51,7 +51,7 @@ const StatsMode = {
 // @delegate : obj (main section object)
 // @monitor  : int (monitor position)
 // =====================================================================
-class StatsView extends FULLSCREEN.Fullscreen{
+var StatsView = class StatsView extends FULLSCREEN.Fullscreen{
     
     constructor (ext, delegate, monitor) {
         super(monitor);

--- a/sections/todo/view__stats.js
+++ b/sections/todo/view__stats.js
@@ -5,7 +5,7 @@ const Pango     = imports.gi.Pango;
 const Clutter   = imports.gi.Clutter;
 const Main      = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
-const Lang      = imports.lang;
+
 const Signals   = imports.signals;
 const Mainloop  = imports.mainloop;
 
@@ -430,7 +430,7 @@ class StatsView extends FULLSCREEN.Fullscreen{
         this.graph_interval_icon.connect('clicked', () => this._toggle_show_intervals());
         this.range_btn.connect('clicked', () => this.range_menu.toggle());
         this.type_btn.connect('clicked', () => this.type_menu.toggle());
-        this.ext.connect('custom-css-changed', () => this._on_custom_css_updated());
+        //this.ext.connect('custom-css-changed', () => this._on_custom_css_updated());
         this.date_picker.connect('date-changed', (_, ...args) => this._on_date_picker_changed(...args));
     }
 

--- a/sections/todo/view__task_editor.js
+++ b/sections/todo/view__task_editor.js
@@ -5,7 +5,7 @@ const Meta     = imports.gi.Meta;
 const Shell    = imports.gi.Shell;
 const Clutter  = imports.gi.Clutter;
 const Main     = imports.ui.main;
-const Lang     = imports.lang;
+
 const Signals  = imports.signals;
 const Mainloop = imports.mainloop;
 
@@ -60,7 +60,7 @@ const EditorMode = {
 class ViewTaskEditor {
     
 
-    _init (ext, delegate, task) {
+    constructor (ext, delegate, task) {
         this.ext      = ext;
         this.delegate = delegate;
 

--- a/sections/todo/view__task_editor.js
+++ b/sections/todo/view__task_editor.js
@@ -57,7 +57,7 @@ const EditorMode = {
 // of that task object and the signals 'delete-task' and 'edit-task' will be
 // used instead of 'add-task'.
 // =====================================================================
-class ViewTaskEditor {
+var ViewTaskEditor  = class ViewTaskEditor {
     
 
     constructor (ext, delegate, task) {

--- a/sections/todo/view__task_editor.js
+++ b/sections/todo/view__task_editor.js
@@ -57,10 +57,10 @@ const EditorMode = {
 // of that task object and the signals 'delete-task' and 'edit-task' will be
 // used instead of 'add-task'.
 // =====================================================================
-var ViewTaskEditor = new Lang.Class({
-    Name: 'Timepp.ViewTaskEditor',
+class ViewTaskEditor {
+    
 
-    _init: function (ext, delegate, task) {
+    _init (ext, delegate, task) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -287,9 +287,9 @@ var ViewTaskEditor = new Lang.Class({
                 break;
             }
         });
-    },
+    }
 
-    _on_text_changed: function () {
+    _on_text_changed () {
         if (this.text_changed_handler_block) return Clutter.EVENT_PROPAGATE;
 
         let text = this.entry.entry.get_text();
@@ -304,9 +304,9 @@ var ViewTaskEditor = new Lang.Class({
         } else {
             this.completion_menu.hide();
         }
-    },
+    }
 
-    _on_tab: function () {
+    _on_tab () {
         this.curr_selected_completion.pseudo_class = '';
         let next = this.curr_selected_completion.get_next_sibling();
 
@@ -319,9 +319,9 @@ var ViewTaskEditor = new Lang.Class({
         }
 
         MISC_UTILS.scroll_to_item(this.completion_menu, this.completion_menu_content, this.curr_selected_completion);
-    },
+    }
 
-    _on_activate: function () {
+    _on_activate () {
         if (!this.completion_menu.visible || !this.curr_selected_completion) {
             this.entry.insert_text('\n');
             return;
@@ -347,9 +347,9 @@ var ViewTaskEditor = new Lang.Class({
         this.curr_selected_completion = null;
         this.completion_menu.hide();
         this.text_changed_handler_block = false;
-    },
+    }
 
-    _on_completion_hovered: function (item) {
+    _on_completion_hovered (item) {
         // It seems that when the completion menu gets hidden, the items are
         // moving for a brief moment which triggers the hover callback.
         // We prevent any possible issues in this case by just checking whether
@@ -359,16 +359,16 @@ var ViewTaskEditor = new Lang.Class({
         this.curr_selected_completion.pseudo_class = '';
         this.curr_selected_completion = item;
         item.pseudo_class = 'active';
-    },
+    }
 
-    _emit_cancel: function () {
+    _emit_cancel () {
         if (this.mode === EditorMode.EDIT_TASK)
             this.preview_task.reset(true, this.old_task_str, false)
 
         this.emit('cancel');
-    },
+    }
 
-    _emit_ok: function () {
+    _emit_ok () {
         if (this.done) return;
 
         let text = this._create_task_str();
@@ -386,9 +386,9 @@ var ViewTaskEditor = new Lang.Class({
 
         if (this.mode === EditorMode.ADD_TASK) this.emit('add-task', r);
         else                                   this.emit('edited-task');
-    },
+    }
 
-    _insert_markdown: function (delim) {
+    _insert_markdown (delim) {
         let text  = this.entry.entry.get_text();
         let pos   = this.entry.entry.clutter_text.get_cursor_position();
         let bound = this.entry.entry.clutter_text.get_selection_bound();
@@ -421,9 +421,9 @@ var ViewTaskEditor = new Lang.Class({
         let l = delim.length;
         if (bound === pos) this.entry.entry.clutter_text.set_selection(pos + l, pos + l);
         else               this.entry.entry.clutter_text.set_selection(start + l, end + l + 1);
-    },
+    }
 
-    _toggle_preview: function () {
+    _toggle_preview () {
         let state = !this.delegate.settings.get_boolean('todo-show-task-editor-preview');
 
         if (state) this.eye_icon.icon_name = 'timepp-eye-symbolic';
@@ -431,9 +431,9 @@ var ViewTaskEditor = new Lang.Class({
 
         this.preview_scrollview.visible = state;
         this.delegate.settings.set_boolean('todo-show-task-editor-preview', state);
-    },
+    }
 
-    _find_file: function () {
+    _find_file () {
         this.ext.menu.close();
         this.file_chooser = MISC_UTILS.open_file_dialog(false, (out) => {
             if (out) this.entry.insert_text(out);
@@ -441,10 +441,10 @@ var ViewTaskEditor = new Lang.Class({
             this.ext.menu.open();
             Mainloop.idle_add(() => this.entry.entry.grab_key_focus());
         });
-    },
+    }
 
     // @word: string (a context or project)
-    _show_completions: function (word) {
+    _show_completions (word) {
         let completions = null;
 
         if (word === '(')
@@ -472,14 +472,14 @@ var ViewTaskEditor = new Lang.Class({
 
         this.completion_menu_content.first_child.pseudo_class = 'active';
         this.curr_selected_completion = this.completion_menu_content.first_child;
-    },
+    }
 
     // @needle   : string (a context or project)
     // @haystack : map    (of all contexts or projects);
     //
     // If @needle is a context, then the @haystack has to be the map of all
     // contexts. Likewise for projects.
-    _find_completions: function (needle, haystack) {
+    _find_completions (needle, haystack) {
         if (needle === '@' || needle === '+') {
             let res = [];
             for (let [key,] of haystack) res.push(key);
@@ -504,9 +504,9 @@ var ViewTaskEditor = new Lang.Class({
         }
 
         return results;
-    },
+    }
 
-    _get_current_word: function () {
+    _get_current_word () {
         let text = this.entry.entry.get_text();
         let len  = text.length;
 
@@ -523,9 +523,9 @@ var ViewTaskEditor = new Lang.Class({
         if (end > 0) end--;
 
         return [text.substring(start, end + 1), start, end];
-    },
+    }
 
-    _create_task_str: function () {
+    _create_task_str () {
         let text = this.entry.entry.get_text();
         if (! text) return "";
 
@@ -548,9 +548,9 @@ var ViewTaskEditor = new Lang.Class({
         }
 
         return words.join(' ').replace(/\n/g, '\\n');
-    },
+    }
 
-    close: function () {
+    close () {
         if (this.file_chooser_proc) this.file_chooser_proc.force_exit();
 
         if (this.preview_task) {
@@ -564,6 +564,6 @@ var ViewTaskEditor = new Lang.Class({
             this.actor.destroy();
             this.delegate.actor.remove_style_class_name('view-task-editor');
         });
-    },
-});
+    }
+}
 Signals.addSignalMethods(ViewTaskEditor.prototype);

--- a/sections/todo/view__task_editor.js
+++ b/sections/todo/view__task_editor.js
@@ -141,7 +141,7 @@ var ViewTaskEditor  = class ViewTaskEditor {
         { // help icon
             let box = new St.BoxLayout({ style_class: 'icon-box' });
             header.add_child(box);
-            this.help_icon = new St.Icon({ icon_name: 'timepp-question-symbolic', can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
+            this.help_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-question-symbolic'), can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
             box.add_child(this.help_icon);
         }
 
@@ -152,29 +152,29 @@ var ViewTaskEditor  = class ViewTaskEditor {
             // group 1
             let icon_group = new St.BoxLayout({ style_class: 'icon-box' });
             box.add_child(icon_group);
-            this.header_icon = new St.Icon({ icon_name: 'timepp-header-symbolic', can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
+            this.header_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-header-symbolic'), can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
             icon_group.add_child(this.header_icon);
-            this.mark_icon = new St.Icon({ icon_name: 'timepp-mark-symbolic', can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
+            this.mark_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-mark-symbolic'), can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
             icon_group.add_child(this.mark_icon);
 
             // group 2
             icon_group = new St.BoxLayout({ style_class: 'icon-box' });
             box.add_child(icon_group);
-            this.bold_icon = new St.Icon({ icon_name: 'timepp-bold-symbolic', can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
+            this.bold_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-bold-symbolic'), can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
             icon_group.add_child(this.bold_icon);
-            this.italic_icon = new St.Icon({ icon_name: 'timepp-italic-symbolic', can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
+            this.italic_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-italic-symbolic'), can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
             icon_group.add_child(this.italic_icon);
-            this.strike_icon = new St.Icon({ icon_name: 'timepp-strike-symbolic', can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
+            this.strike_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-strike-symbolic'), can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
             icon_group.add_child(this.strike_icon);
-            this.underscore_icon = new St.Icon({ icon_name: 'timepp-underscore-symbolic', can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
+            this.underscore_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-underscore-symbolic'), can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
             icon_group.add_child(this.underscore_icon);
 
             // group 3
             icon_group = new St.BoxLayout({ style_class: 'icon-box' });
             box.add_child(icon_group);
-            this.link_icon = new St.Icon({ icon_name: 'timepp-link-symbolic', can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
+            this.link_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-link-symbolic'), can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
             icon_group.add_child(this.link_icon);
-            this.code_icon = new St.Icon({ icon_name: 'timepp-code-symbolic', can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
+            this.code_icon = new St.Icon({ gicon : MISC_UTILS.getIcon('timepp-code-symbolic'), can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
             icon_group.add_child(this.code_icon);
 
             // group 4
@@ -182,8 +182,8 @@ var ViewTaskEditor  = class ViewTaskEditor {
             box.add_child(icon_group);
             this.eye_icon = new St.Icon({ can_focus: true, reactive: true, track_hover: true, x_align: Clutter.ActorAlign.START, y_align: Clutter.ActorAlign.CENTER, });
             icon_group.add_child(this.eye_icon);
-            if (this.preview_scrollview.visible) this.eye_icon.icon_name = 'timepp-eye-symbolic';
-            else                                 this.eye_icon.icon_name = 'timepp-eye-closed-symbolic'
+            if (this.preview_scrollview.visible) this.eye_icon.gicon = MISC_UTILS.getIcon('timepp-eye-symbolic');
+            else                                 this.eye_icon.gicon = MISC_UTILS.getIcon('timepp-eye-closed-symbolic')
         }
 
 
@@ -426,8 +426,8 @@ var ViewTaskEditor  = class ViewTaskEditor {
     _toggle_preview () {
         let state = !this.delegate.settings.get_boolean('todo-show-task-editor-preview');
 
-        if (state) this.eye_icon.icon_name = 'timepp-eye-symbolic';
-        else       this.eye_icon.icon_name = 'timepp-eye-closed-symbolic'
+        if (state) this.eye_icon.gicon = MISC_UTILS.getIcon('timepp-eye-symbolic');
+        else       this.eye_icon.gicon = MISC_UTILS.getIcon('timepp-eye-closed-symbolic')
 
         this.preview_scrollview.visible = state;
         this.delegate.settings.set_boolean('todo-show-task-editor-preview', state);

--- a/sections/todo/view_manager.js
+++ b/sections/todo/view_manager.js
@@ -1,7 +1,7 @@
 const Gtk      = imports.gi.Gtk;
 const Clutter  = imports.gi.Clutter;
 const Main     = imports.ui.main;
-const Lang     = imports.lang;
+
 const Signals  = imports.signals;
 const Mainloop = imports.mainloop;
 
@@ -27,7 +27,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 class ViewManager {
     
 
-    _init (ext, delegate) {
+    constructor (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 

--- a/sections/todo/view_manager.js
+++ b/sections/todo/view_manager.js
@@ -24,7 +24,7 @@ const G = ME.imports.sections.todo.GLOBAL;
 // - To switch to a new view, use the show_view function of this object.
 // - The current_view is always stored in the current_view var of this obj.
 // =====================================================================
-class ViewManager {
+var ViewManager  = class ViewManager {
     
 
     constructor (ext, delegate) {

--- a/sections/todo/view_manager.js
+++ b/sections/todo/view_manager.js
@@ -24,10 +24,10 @@ const G = ME.imports.sections.todo.GLOBAL;
 // - To switch to a new view, use the show_view function of this object.
 // - The current_view is always stored in the current_view var of this obj.
 // =====================================================================
-var ViewManager = new Lang.Class({
-    Name: 'Timepp.ViewManager',
+class ViewManager {
+    
 
-    _init: function (ext, delegate) {
+    _init (ext, delegate) {
         this.ext      = ext;
         this.delegate = delegate;
 
@@ -35,21 +35,21 @@ var ViewManager = new Lang.Class({
         this.container = this.delegate.actor;
 
         this.reset();
-    },
+    }
 
-    reset: function () {
+    reset () {
         this.current_view           = null;
         this.current_view_name      = "";
         this.actors                 = [];
         this.open_callback          = null;
         this.close_callback         = null;
         this.show_tasks_mainloop_id = null;
-    },
+    }
 
-    close_current_view: function () {
+    close_current_view () {
         if (typeof this.close_callback === 'function') this.close_callback();
         this.reset();
-    },
+    }
 
     // @view_params: object of the form: { view           : object
     //                                     view_name      : View
@@ -63,7 +63,7 @@ var ViewManager = new Lang.Class({
     //   methods on it.
     //
     // @view_name:
-    //   Name of the new view. Only use the View enum here.
+    //   
     //
     // @actors (can be omitted if @open_callback is given):
     //   Array of all the top-level actors that need to be in the popup
@@ -79,7 +79,7 @@ var ViewManager = new Lang.Class({
     // @open_callback (optional):
     //   Function that is used to open the view. If it is not given, then
     //   opening the view means that the actors will be added to the popup menu.
-    show_view: function (view_params) {
+    show_view (view_params) {
         if (typeof this.close_callback === 'function') this.close_callback();
 
         this.current_view      = view_params.view || null;
@@ -102,6 +102,6 @@ var ViewManager = new Lang.Class({
         if (view_params.focused_actor && this.ext.menu.isOpen) {
             view_params.focused_actor.grab_key_focus();
         }
-    },
-});
+    }
+}
 Signals.addSignalMethods(ViewManager.prototype);


### PR DESCRIPTION
With the GNOME update to 3.32, which requires pure ES6 classes, this extension stopped working.
I've tried fixing it, now it works but all the icons are missing.
I had to comment out all the instructions which used the signal `custom-css-changed` because, otherwise, GNOME would throw an error about it not existing in `Gjs_Timepp` and I think this is strictly related.
I have no idea what to do next so I'm sharing my changes, hoping they could be useful.
