### PR TITLE
fix alarm day selection indicator colors

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -508,6 +508,12 @@
 .timepp-menu .alarm-section .numpicker-box {}
 .timepp-menu .alarm-section .numpicker-box {}
 
+.timepp-menu .alarm-section .day.button {}
+
+.timepp-menu .alarm-section .day.button:active {
+    color: #5a94dc;
+}
+
 .timepp-menu .alarm-section .entry-container {}
 
 .timepp-menu .alarm-section .add-alarm:hover,


### PR DESCRIPTION
For my machine Ubuntu 19.04 / gnome shell 3.32.0 the day chooser was not showing what days were checked or not - the buttons were always plain white.

I added a blue color to indicate selected days:

![time__day-selection-fix](https://user-images.githubusercontent.com/1133427/58862765-b2496a80-86b1-11e9-9d7b-2942597ae73b.png)
