### PR TITLE
remove unhandled key:val tags before rendering

### DIFF
--- a/lib/regex.js
+++ b/lib/regex.js
@@ -18,3 +18,4 @@ var TODO_REC_EXT_2      = /^\s*rec:x-[1-9][0-9]*[dw]\s*$/;
 var TODO_REC_EXT_3      = /^\s*rec:[1-9][0-9]*d-[1-9][0-9]*m\s*$/;
 var TODO_DUE_EXT        = /^\s*(?:due|DUE):\d{4}-\d{2}-\d{2}\s*$/;
 var TODO_TRACKER_ID_EXT = /^\s*tracker_id:[^:]+\s*$/;
+var TODO_KEY_VAL_TAGS   = /\S+:(\S+)\s*/g;

--- a/sections/todo/task_item.js
+++ b/sections/todo/task_item.js
@@ -438,6 +438,8 @@ var TaskItem  = class TaskItem {
         this.description_markup = words;
 
         words = words.join('');
+	// Remove key:val tags before rendering
+	words = words.replace(REG.TODO_KEY_VAL_TAGS, '');
         words = MISC.markdown_to_pango(words, this.ext.markdown_map);
 
         this.msg.clutter_text.set_markup(words);
@@ -621,6 +623,8 @@ var TaskItem  = class TaskItem {
         }
 
         let markup = this.description_markup.join('');
+	// Remove key:val tags before rendering
+	markup     = markup.replace(REG.TODO_KEY_VAL_TAGS, '');
         markup     = MISC.markdown_to_pango(markup, this.ext.markdown_map);
 
         this.msg.clutter_text.set_markup(markup);


### PR DESCRIPTION
I use a synchronisation script that syncs my todo.txt file with a remote provider (todoist). The script adds some specific tags (mostly ids) that shouldn't be rendered in task title (according to todo.txt specs).

These change allow to strip all these unhandled tags from being in the task title.