### PR TITLE
Fix 3.34.2 and 3.36

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -106,14 +106,14 @@ var Timepp = GObject.registerClass({
                 }
             };
 
-            this.actor.style_class = '';
-            this.actor.can_focus   = false;
-            this.actor.reactive    = false;
+            this.style_class = '';
+            this.can_focus   = false;
+            this.reactive    = false;
             this.menu.actor.add_style_class_name('timepp-menu');
 
 
             this.panel_item_box = new St.BoxLayout({ style_class: 'timepp-panel-box timepp-custom-css-root'});
-            this.actor.add_actor(this.panel_item_box);
+            this.add_actor(this.panel_item_box);
 
 
             this.markdown_map = new Map([

--- a/sections/context_menu.js
+++ b/sections/context_menu.js
@@ -1,5 +1,6 @@
 const St        = imports.gi.St;
 const Gio       = imports.gi.Gio
+const GObject   = imports.gi.GObject
 const PopupMenu = imports.ui.popupMenu;
 const Util      = imports.misc.util;
 
@@ -23,7 +24,7 @@ const MISC_UTILS = ME.imports.lib.misc_utils;
 // @ext: obj (main extension object)
 // =====================================================================
 var ContextMenu  = class ContextMenu {
-    
+
 
     constructor (ext) {
         this.actor = new St.BoxLayout({ vertical: true, style_class: 'section context-menu-section', x_expand: true });
@@ -74,15 +75,19 @@ var ContextMenu  = class ContextMenu {
 // @icon_name : string
 // @label     : string
 // =====================================================================
-var PopupMenuIconItem = class PopupMenuIconItem extends PopupMenu.PopupBaseMenuItem{
-    
-    constructor (icon_name, label, params) {
-        super(params);
+var PopupMenuIconItem = GObject.registerClass({
+        GTypeName: 'PopupMenuIconItem'
+    },
+
+    class PopupMenuIconItem extends PopupMenu.PopupBaseMenuItem{
+
+    _init (icon_name, label, params) {
+        super._init(params);
 
         this.icon = new St.Icon({ gicon: MISC_UTILS.getIcon(icon_name) });
-        this.actor.add_child(this.icon);
+        this.add_child(this.icon);
 
         this.label = new St.Label({ text: label });
-        this.actor.add_child(this.label);
+        this.add_child(this.label);
     }
-}
+})


### PR DESCRIPTION
The extension didn't load on recent gnome shell versions thanks to breaking changes in the gnome-shell API. I am not a shell extension developer, so I just did what I could. There is definitely other bugs, but at least this allows the extension to load.

As for the second commit I found some inspiration here: https://wiki.gnome.org/Projects/GnomeShell/Extensions/MigratingShellClasses