### PR TITLE
Maybe

### DIFF
--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -273,7 +273,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
             editor.connect('edited-alarm', (_, alarm) => {
                 this.snoozed_alarms.delete(alarm);
 
-                alarm_item.toggle.setToggleState(alarm.toggle);
+                alarm_item.toggle.state = alarm.toggle;
                 alarm_item.update_time_label();
                 alarm_item.alarm_item_content.show();
 


### PR DESCRIPTION
error to save alarms
```
JS ERROR: Exception in callback for signal: edited-alarm: TypeError: alarm_item.toggle.setToggleState is not a function
                                                      alarm_editor/<@/home/user/.local/share/gnome-shell/extensions/timepp@zagortenay333/sections/alarms.js:276:35
```