### PR TITLE
Crash and JS Error Fixes (Gnome Shell 3.36.4)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -604,7 +604,7 @@ var Timepp = GObject.registerClass({
     destroy () {
         // We need to make sure that this one is set to the default actor or
         // else the shell will try to destroy the wrong panel actor.
-        this._update_menu_arrow(this.actor);
+        this._update_menu_arrow(this);
 
         for (let [, section] of this.sections) section.disable_section();
 

--- a/extension.js
+++ b/extension.js
@@ -567,22 +567,15 @@ var Timepp = GObject.registerClass({
             }
         }
 
-        // St.ThemeContext.get_for_stage(global.stage).get_theme().load_stylesheet(this.custom_stylesheet);
-
-        // // reload theme
-        // Main.reloadThemeResource();
-        // Main.loadTheme();
-
-        // Mainloop.idle_add(() => this.theme_change_signal_block = false);
         if (this.custom_stylesheet) {
             Mainloop.idle_add(() => {
                 try {
+                    // reload theme
                     St.ThemeContext.get_for_stage(global.stage).set_theme(new St.Theme());
                     St.ThemeContext.get_for_stage(global.stage).get_theme().load_stylesheet(this.custom_stylesheet);
                     Main.reloadThemeResource();
                     Main.loadTheme();
                 } catch {
-                    log('* timepp.extension | load stylesheet error *');
                     // ignore upstream issue sometimes after screen locking
                     // Argument 'file' (type interface) may not be null loadTheme@resource:///org/gnome/shell/ui/main.js:428:19
                 }
@@ -596,19 +589,16 @@ var Timepp = GObject.registerClass({
 
     _unload_stylesheet () {
         if (! this.custom_stylesheet) return;
-        // St.ThemeContext.get_for_stage(global.stage).get_theme().unload_stylesheet(this.custom_stylesheet);
-        // this.custom_stylesheet = null;
         Mainloop.idle_add(() => {
             try {
                 St.ThemeContext.get_for_stage(global.stage).get_theme().unload_stylesheet(this.custom_stylesheet);
                 this.custom_stylesheet = null;
-                if (this.isDestroying) {
+                if (this.isDestroying) { // Only reset when destroying
                     St.ThemeContext.get_for_stage(global.stage).set_theme(new St.Theme());
                     Main.reloadThemeResource();
                     Main.loadTheme();
                 }
             } catch {
-                log('* timepp.extension | unload stylesheet error *');
                 // ignore upstream issue sometimes after screen locking
                 // Argument 'file' (type interface) may not be null loadTheme@resource:///org/gnome/shell/ui/main.js:428:19
             }
@@ -636,6 +626,7 @@ var Timepp = GObject.registerClass({
         return max_h >= 0 && nat_h >= max_h;
     }
 
+    // Calling destroy on Clutter.Actor isn't safe, so we override _onDestroy
     _onDestroy () {
         this.isDestroying = true;
         // We need to make sure that this one is set to the default actor or

--- a/extension.js
+++ b/extension.js
@@ -588,7 +588,11 @@ var Timepp = GObject.registerClass({
     }
 
     _unload_stylesheet () {
-        if (! this.custom_stylesheet) return;
+        // Also avoid unloading the stylesheet while on lock screen
+        if (
+            ! this.custom_stylesheet
+            || (Main.sessionMode.currentMode === 'unlock-dialog' && ! this.isDestroying)
+        ) return;
         Mainloop.idle_add(() => {
             try {
                 St.ThemeContext.get_for_stage(global.stage).get_theme().unload_stylesheet(this.custom_stylesheet);

--- a/lib/fullscreen.js
+++ b/lib/fullscreen.js
@@ -116,9 +116,10 @@ var Fullscreen = class Fullscreen{
             });
         this.osd_keyboard_id =
             Main.layoutManager.connect('keyboard-visible-changed', (_, state) => {
-                if (this.open && state)
+                if (this.open && state) {
                     const parent = Main.layoutManager.keyboardBox.get_parent();
                     if (parent) parent.set_child_above_sibling(Main.layoutManager.keyboardBox, null);
+                }
             });
         this.banner_container.connect('allocation-changed', () => {
             if (this.open && !this.banner_container_handler_block)

--- a/lib/fullscreen.js
+++ b/lib/fullscreen.js
@@ -117,7 +117,8 @@ var Fullscreen = class Fullscreen{
         this.osd_keyboard_id =
             Main.layoutManager.connect('keyboard-visible-changed', (_, state) => {
                 if (this.open && state)
-                    Main.layoutManager.keyboardBox.raise_top();
+                    const parent = Main.layoutManager.keyboardBox.get_parent();
+                    if (parent) parent.set_child_above_sibling(Main.layoutManager.keyboardBox, null);
             });
         this.banner_container.connect('allocation-changed', () => {
             if (this.open && !this.banner_container_handler_block)
@@ -181,9 +182,10 @@ var Fullscreen = class Fullscreen{
     }
 
     open () {
+        const parent = this.actor.get_parent();
         if (this.is_open) {
             this.actor.grab_key_focus();
-            this.actor.raise_top();
+            if (parent) parent.set_child_above_sibling(this.actor, null);
             return;
         }
 
@@ -191,7 +193,7 @@ var Fullscreen = class Fullscreen{
         Main.layoutManager.addChrome(this.actor);
         this.actor.grab_key_focus();
         this.banner_container_handler_block = false;
-        this.actor.raise_top();
+        if (parent) parent.set_child_above_sibling(this.actor, null);
 
         if (this.banner_size_update_needed) this._update_banner_size();
 

--- a/lib/graphs.js
+++ b/lib/graphs.js
@@ -480,7 +480,8 @@ var VBars = class VBars {
             if (tooltip_h > delta_y) tooltip_y -= tooltip_h - delta_y;
 
             this.vbar_tooltip.set_position(tooltip_x - h_scroll, tooltip_y);
-            this.vbar_tooltip.raise_top();
+            const parent = this.vbar_tooltip.get_parent();
+            if (parent) parent.set_child_above_sibling(this.vbar_tooltip, null);
         }
 
         this.selected_vbar = found;
@@ -792,7 +793,8 @@ var HeatMap = class HeatMap {
             if (tooltip_h > delta_y) tooltip_y -= tooltip_h - delta_y;
 
             this.heatmap_tooltip.set_position(tooltip_x - h_scroll, tooltip_y);
-            this.heatmap_tooltip.raise_top();
+            const parent = this.heatmap_tooltip.get_parent();
+            if (parent) parent.set_child_above_sibling(this.heatmap_tooltip, null);
         }
     }
 }

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -667,7 +667,7 @@ var AlarmItem = class AlarmItem {
 
         this.toggle     = new PopupMenu.Switch(alarm.toggle);
         this.toggle_bin = new St.Button({can_focus: true, y_align: St.Align.START, x_align: St.Align.END });
-        this.toggle_bin.add_actor(this.toggle.actor);
+        this.toggle_bin.add_actor(this.toggle);
         this.icon_box.add(this.toggle_bin);
 
 

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -572,7 +572,7 @@ var AlarmEditor = class AlarmEditor{
 
         this.button_cancel = new St.Button({ can_focus: true, label: _('Cancel'), style_class: 'btn-cancel button', x_expand: true });
         this.button_ok     = new St.Button({ can_focus: true, label: _('Ok'), style_class: 'btn-ok button', x_expand: true });
-        btn_box.add(this.button_cancel, {expand: true });
+        btn_box.add(this.button_cancel);
         btn_box.add(this.button_ok);
 
 

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -364,7 +364,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         } else if (notif_style === NotifStyle.FULLSCREEN) {
             this.fullscreen.fire_alarm(alarm);
         } else {
-            let source = new MessageTray.Source();
+            let source = new MessageTray.Source('Timepp - Alarm', ME.path + '/data/img/icons/timepp-timer-symbolic.svg');
             Main.messageTray.add(source);
             source.connect('destroy', () => this.sound_player.stop());
 
@@ -388,7 +388,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
                 this.snooze_alarm(alarm);
             });
 
-            source.notify(notif);
+            source.showNotification(notif);
         }
 
         if (this.settings.get_boolean('alarms-play-sound')) {

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -535,8 +535,8 @@ var AlarmEditor = class AlarmEditor{
             new St.Label({ text: _('Repeat notification sound?'), x_expand: true, y_align: Clutter.ActorAlign.CENTER }));
 
         this.sound_checkbox = new CheckBox.CheckBox();
-        this.checkbox_item.add_child(this.sound_checkbox.actor);
-        this.sound_checkbox.actor.checked = alarm && alarm.repeat_sound;
+        this.checkbox_item.add_child(this.sound_checkbox);
+        this.sound_checkbox.checked = alarm && alarm.repeat_sound;
 
 
         //
@@ -585,7 +585,7 @@ var AlarmEditor = class AlarmEditor{
                 alarm.msg          = this.entry.entry.get_text(),
                 alarm.days         = this.day_chooser.get_days(),
                 alarm.snooze_dur   = this.snooze_duration_picker.counter;
-                alarm.repeat_sound = this.sound_checkbox.actor.checked;
+                alarm.repeat_sound = this.sound_checkbox.checked;
 
                 this.emit('edited-alarm', alarm);
             }
@@ -596,7 +596,7 @@ var AlarmEditor = class AlarmEditor{
                     days         : this.day_chooser.get_days(),
                     toggle       : true,
                     snooze_dur   : this.snooze_duration_picker.counter,
-                    repeat_sound : this.sound_checkbox.actor.checked,
+                    repeat_sound : this.sound_checkbox.checked,
                 });
             }
         });
@@ -604,7 +604,7 @@ var AlarmEditor = class AlarmEditor{
             this.emit('cancel');
         });
         this.checkbox_item.connect('button-press-event', () => {
-            this.sound_checkbox.actor.checked = !this.sound_checkbox.actor.checked;
+            this.sound_checkbox.checked = !this.sound_checkbox.checked;
         });
         this.entry.entry.connect('allocation-changed', () => {
             this.entry.scroll_box.vscrollbar_policy = Gtk.PolicyType.NEVER;

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -563,7 +563,7 @@ var AlarmEditor = class AlarmEditor{
 
         if (alarm) {
             this.button_delete = new St.Button({ can_focus: true, label: _('Delete'), style_class: 'btn-delete button', x_expand: true });
-            btn_box.add(this.button_delete, {expand: true});
+            btn_box.add(this.button_delete);
 
             this.button_delete.connect('clicked', () => {
                 this.emit('delete-alarm');
@@ -573,7 +573,7 @@ var AlarmEditor = class AlarmEditor{
         this.button_cancel = new St.Button({ can_focus: true, label: _('Cancel'), style_class: 'btn-cancel button', x_expand: true });
         this.button_ok     = new St.Button({ can_focus: true, label: _('Ok'), style_class: 'btn-ok button', x_expand: true });
         btn_box.add(this.button_cancel, {expand: true });
-        btn_box.add(this.button_ok, {expand: true});
+        btn_box.add(this.button_ok);
 
 
         //
@@ -657,7 +657,7 @@ var AlarmItem = class AlarmItem {
         this.alarm_item_content.add_actor(this.header);
 
         this.time = new St.Label({ y_align: St.Align.END, x_align: St.Align.START, style_class: 'alarm-item-time' });
-        this.header.add(this.time, {expand: true});
+        this.header.add(this.time);
 
         this.icon_box = new St.BoxLayout({y_align: Clutter.ActorAlign.CENTER, x_align: Clutter.ActorAlign.CENTER, style_class: 'icon-box'});
         this.header.add_actor(this.icon_box);

--- a/sections/alarms.js
+++ b/sections/alarms.js
@@ -273,7 +273,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
             editor.connect('edited-alarm', (_, alarm) => {
                 this.snoozed_alarms.delete(alarm);
 
-                alarm_item.toggle.setToggleState(alarm.toggle);
+                alarm_item.toggle._state = alarm.toggle;
                 alarm_item.update_time_label();
                 alarm_item.alarm_item_content.show();
 

--- a/sections/context_menu.js
+++ b/sections/context_menu.js
@@ -48,7 +48,7 @@ var ContextMenu = class ContextMenu {
         // listen
         //
         this.settings_link.connect('activate', () => {
-            Util.spawn(["gnome-shell-extension-prefs", ME.metadata.uuid]);
+            Util.spawn(["gnome-extensions", "prefs", ME.metadata.uuid]);
             ext.toggle_context_menu();
         });
         this.website_link.connect('activate', () => {

--- a/sections/pomodoro.js
+++ b/sections/pomodoro.js
@@ -599,7 +599,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
                 this.notif_source.destroyNonResidentNotifications();
             }
 
-            this.notif_source = new MessageTray.Source();
+            this.notif_source = new MessageTray.Source('Timepp - Pomodoro', ME.path + '/data/img/icons/timepp-timer-symbolic.svg');
             Main.messageTray.add(this.notif_source);
             this.notif_source.connect('destroy', () => this.sound_player.stop());
 
@@ -612,7 +612,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
             let notif = new MessageTray.Notification(this.notif_source, msg, '', params);
             notif.setUrgency(MessageTray.Urgency.NORMAL);
 
-            this.notif_source.notify(notif);
+            this.notif_source.showNotification(notif);
         }
 
         if (do_play_sound)

--- a/sections/pomodoro.js
+++ b/sections/pomodoro.js
@@ -658,7 +658,7 @@ var PomodoroSettings = class PomodoroSettings {
         this.actor = new St.BoxLayout({style_class: 'view-box'});
 
         this.content_box = new St.BoxLayout({vertical: true, style_class: 'view-box-content'});
-        this.actor.add(this.content_box, {expand: true});
+        this.actor.add(this.content_box);
 
 
         //
@@ -668,7 +668,7 @@ var PomodoroSettings = class PomodoroSettings {
         this.content_box.add_actor(this.clear_all_item);
 
         this.clear_item_label = new St.Label({text: `${_('Reset pomodoro counter?')} `, y_align: Clutter.ActorAlign.CENTER});
-        this.clear_all_item.add(this.clear_item_label, {expand: true});
+        this.clear_all_item.add(this.clear_item_label);
 
         this.clear_checkbox_bin = new St.Bin();
         this.clear_all_item.add_actor(this.clear_checkbox_bin);
@@ -684,7 +684,7 @@ var PomodoroSettings = class PomodoroSettings {
         this.content_box.add_actor(this.pomo_duration);
 
         this.pomo_label = new St.Label({text: `${POMO_STARTED_MSG} ${_('(min:sec)')} `, y_align: Clutter.ActorAlign.CENTER});
-        this.pomo_duration.add(this.pomo_label, {expand: true});
+        this.pomo_duration.add(this.pomo_label);
 
         this.pomo_dur_min_picker = new NUM_PICKER.NumPicker(0, null);
         this.pomo_duration.add_actor(this.pomo_dur_min_picker.actor);
@@ -703,7 +703,7 @@ var PomodoroSettings = class PomodoroSettings {
         this.content_box.add_actor(this.short_break);
 
         this.short_break_label = new St.Label({text: `${SHORT_BREAK_MSG} ${_('(min:sec)')} `, y_align: Clutter.ActorAlign.CENTER});
-        this.short_break.add(this.short_break_label, {expand: true});
+        this.short_break.add(this.short_break_label);
 
         this.short_break_min_picker = new NUM_PICKER.NumPicker(0, null);
         this.short_break.add_actor(this.short_break_min_picker.actor);
@@ -722,7 +722,7 @@ var PomodoroSettings = class PomodoroSettings {
         this.content_box.add_actor(this.long_break);
 
         this.long_break_label = new St.Label({text: `${LONG_BREAK_MSG} ${_('(min:sec)')} `, y_align: Clutter.ActorAlign.CENTER});
-        this.long_break.add(this.long_break_label, {expand: true});
+        this.long_break.add(this.long_break_label);
 
         this.long_break_min_picker = new NUM_PICKER.NumPicker(0, null);
         this.long_break.add_actor(this.long_break_min_picker.actor);
@@ -741,7 +741,7 @@ var PomodoroSettings = class PomodoroSettings {
         this.content_box.add_actor(this.long_break_rate);
 
         this.long_break_rate_label = new St.Label({text: `${_('Num of pomos until long break')} `, y_align: Clutter.ActorAlign.CENTER});
-        this.long_break_rate.add(this.long_break_rate_label, {expand: true});
+        this.long_break_rate.add(this.long_break_rate_label);
 
         this.long_break_rate_picker = new NUM_PICKER.NumPicker(1, null);
         this.long_break_rate.add_actor(this.long_break_rate_picker.actor);
@@ -767,13 +767,13 @@ var PomodoroSettings = class PomodoroSettings {
         // buttons
         //
         this.button_box = new St.BoxLayout({ style_class: 'row btn-box' });
-        this.content_box.add(this.button_box, {expand: true});
+        this.content_box.add(this.button_box);
 
         this.button_ok      = new St.Button({can_focus: true, label: _('Ok'), x_expand: true, style_class: 'button'});
         this.button_cancel = new St.Button({can_focus: true, label: _('Cancel'), x_expand: true, style_class: 'button'});
 
-        this.button_box.add(this.button_cancel, {expand: true});
-        this.button_box.add(this.button_ok, {expand: true});
+        this.button_box.add(this.button_cancel);
+        this.button_box.add(this.button_ok);
 
 
         //

--- a/sections/pomodoro.js
+++ b/sections/pomodoro.js
@@ -674,7 +674,7 @@ var PomodoroSettings = class PomodoroSettings {
         this.clear_all_item.add_actor(this.clear_checkbox_bin);
 
         this.clear_item_checkbox = new CheckBox.CheckBox();
-        this.clear_checkbox_bin.add_actor(this.clear_item_checkbox.actor);
+        this.clear_checkbox_bin.add_actor(this.clear_item_checkbox);
 
 
         //
@@ -781,7 +781,7 @@ var PomodoroSettings = class PomodoroSettings {
         //
         this.button_ok.connect('clicked', () => {
             this.emit('ok', {
-                clear_counter : this.clear_item_checkbox.actor.checked,
+                clear_counter : this.clear_item_checkbox.checked,
                 break_rate    : this.long_break_rate_picker.counter,
                 pomo          : this.pomo_dur_min_picker.counter * 60 +
                                 this.pomo_dur_sec_picker.counter,

--- a/sections/timer.js
+++ b/sections/timer.js
@@ -979,8 +979,8 @@ var TimerPresetEditor = class TimerPresetEditor {
             new St.Label({ text: _('Repeat notification sound?'), x_expand: true, y_align: Clutter.ActorAlign.CENTER }));
 
         this.sound_checkbox = new CheckBox.CheckBox();
-        this.checkbox_item.add_child(this.sound_checkbox.actor);
-        this.sound_checkbox.actor.checked = preset ? preset.repeat_sound : false;
+        this.checkbox_item.add_child(this.sound_checkbox);
+        this.sound_checkbox.checked = preset ? preset.repeat_sound : false;
 
 
         //
@@ -1013,12 +1013,12 @@ var TimerPresetEditor = class TimerPresetEditor {
             this.emit('ok', {
                 time         : this._get_time(),
                 msg          : this.entry.entry.get_text(),
-                repeat_sound : this.sound_checkbox.actor.checked,
+                repeat_sound : this.sound_checkbox.checked,
             });
         });
         this.button_cancel.connect('clicked', () => this.emit('cancel'));
         this.checkbox_item.connect('button-press-event', () => {
-            this.sound_checkbox.actor.checked = !this.sound_checkbox.actor.checked;
+            this.sound_checkbox.checked = !this.sound_checkbox.checked;
         });
     }
 

--- a/sections/timer.js
+++ b/sections/timer.js
@@ -679,8 +679,8 @@ var TimerPresetsView = class TimerPresetsView {
         this.content_box.add_child(btn_box);
         this.button_add_preset = new St.Button({ can_focus: true, label: _('Add Preset'), style_class: 'button', x_expand: true });
         this.button_ok         = new St.Button({ can_focus: true, label: _('Ok'), style_class: 'button', x_expand: true });
-        btn_box.add(this.button_add_preset, {expand: true});
-        btn_box.add(this.button_ok, {expand: true});
+        btn_box.add(this.button_add_preset);
+        btn_box.add(this.button_ok);
 
 
         //
@@ -961,7 +961,7 @@ var TimerPresetEditor = class TimerPresetEditor {
         this.actor.add_actor(this.entry_container);
 
         this.entry = new MULTIL_ENTRY.MultiLineEntry(_('Timer message...'), true);
-        this.entry_container.add(this.entry.actor, {expand: true});
+        this.entry_container.add(this.entry.actor);
 
         this.entry.scroll_box.vscrollbar_policy = Gtk.PolicyType.NEVER;
         this.entry.scroll_box.hscrollbar_policy = Gtk.PolicyType.NEVER;
@@ -987,18 +987,18 @@ var TimerPresetEditor = class TimerPresetEditor {
         // buttons
         //
         let btn_box = new St.BoxLayout({ style_class: 'row btn-box' });
-        this.actor.add(btn_box, {expand: true});
+        this.actor.add(btn_box);
 
         if (is_deletable) {
             this.button_delete = new St.Button({ can_focus: true, label: _('Delete'), style_class: 'btn-delete button', x_expand: true });
-            btn_box.add(this.button_delete, {expand: true});
+            btn_box.add(this.button_delete);
             this.button_delete.connect('clicked', () => this.emit('delete'));
         }
 
         this.button_cancel = new St.Button({ can_focus: true, label: _('Cancel'), style_class: 'btn-cancel button', x_expand: true });
         this.button_ok     = new St.Button({ can_focus: true, label: _('Ok'), style_class: 'btn-ok button', x_expand: true });
-        btn_box.add(this.button_cancel, {expand: true});
-        btn_box.add(this.button_ok, {expand: true});
+        btn_box.add(this.button_cancel);
+        btn_box.add(this.button_ok);
 
 
 

--- a/sections/timer.js
+++ b/sections/timer.js
@@ -197,7 +197,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
             this.slider_item = new St.BoxLayout({ vertical: true, style_class: 'timepp-menu-item' });
             this.actor.add_child(this.slider_item);
             this.slider = new Slider.Slider(0);
-            this.slider_item.add_actor(this.slider.actor);
+            this.slider_item.add_actor(this.slider);
         }
 
 
@@ -226,7 +226,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         this.sigm.connect_release(this.settings_icon, Clutter.BUTTON_PRIMARY, true, () => this._show_presets());
         this.sigm.connect(this.slider, 'notify::value', () => this.slider_changed(this.slider.value));
         this.sigm.connect(this.slider, 'drag-end', () => this.slider_released());
-        this.sigm.connect(this.slider.actor, 'scroll-event', () => this.slider_released());
+        this.sigm.connect(this.slider, 'scroll-event', () => this.slider_released());
     }
 
     disable_section () {
@@ -1072,8 +1072,8 @@ var TimerFullscreen = class TimerFullscreen extends FULLSCREEN.Fullscreen {
         this.middle_box.insert_child_at_index(this.title, 0);
 
         this.slider = new Slider.Slider(0);
-        this.bottom_box.add_child(this.slider.actor);
-        this.slider.actor.can_focus = true;
+        this.bottom_box.add_child(this.slider);
+        this.slider.can_focus = true;
 
         this.start_pause_btn = new St.Button();
         this.top_box.insert_child_at_index(this.start_pause_btn, 0);
@@ -1090,7 +1090,7 @@ var TimerFullscreen = class TimerFullscreen extends FULLSCREEN.Fullscreen {
         this.slider.connect('drag-end', () => {
             this.delegate.slider_released();
         });
-        this.slider.actor.connect('scroll-event', () => {
+        this.slider.connect('scroll-event', () => {
             this.delegate.slider_released();
             this.title.text = '';
         });

--- a/sections/timer.js
+++ b/sections/timer.js
@@ -468,7 +468,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
                 this.notif_source.destroyNonResidentNotifications();
             }
 
-            this.notif_source = new MessageTray.Source();
+            this.notif_source = new MessageTray.Source('Timepp - Timer', ME.path + '/data/img/icons/timepp-timer-symbolic.svg');
             Main.messageTray.add(this.notif_source);
             this.notif_source.connect('destroy', () => this.sound_player.stop());
 
@@ -486,7 +486,7 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
             );
 
             notif.setUrgency(MessageTray.Urgency.CRITICAL);
-            this.notif_source.notify(notif);
+            this.notif_source.showNotification(notif);
         }
 
         if (this.settings.get_boolean('timer-play-sound')) {

--- a/sections/todo/task_item.js
+++ b/sections/todo/task_item.js
@@ -755,7 +755,7 @@ var TaskItem = class TaskItem {
         if (this.header_icon_box) return;
 
         this.header_icon_box = new St.BoxLayout({ x_align: Clutter.ActorAlign.END, style_class: 'icon-box' });
-        this.header.add(this.header_icon_box, {expand: true});
+        this.header.add(this.header_icon_box);
 
         this.stat_icon = new St.Icon({ visible:false, reactive: true, can_focus: true, track_hover: true, gicon : MISC.getIcon('timepp-graph-symbolic') });
         this.header_icon_box.add_actor(this.stat_icon);

--- a/sections/todo/view__clear_tasks.js
+++ b/sections/todo/view__clear_tasks.js
@@ -90,10 +90,10 @@ var ViewClearTasks = class ViewClearTasks {
         this.content_box.add_child(this.btn_box);
 
         this.button_delete = new St.Button({ can_focus: true, label: _('Delete'), style_class: 'btn-delete button', x_expand: true });
-        this.btn_box.add(this.button_delete, {expand: true});
+        this.btn_box.add(this.button_delete);
 
         this.button_cancel = new St.Button({ can_focus: true, label: _('Cancel'), style_class: 'btn-cancel button notification-icon-button modal-dialog-button' });
-        this.btn_box.add(this.button_cancel, {expand: true});
+        this.btn_box.add(this.button_cancel);
 
 
         //

--- a/sections/todo/view__file_switcher.js
+++ b/sections/todo/view__file_switcher.js
@@ -91,15 +91,15 @@ var ViewFileSwitcher = class ViewFileSwitcher {
         this.content_box.add_child(btn_box);
 
         this.button_add_file = new St.Button({ can_focus: true, label: _('Add File'), style_class: 'button', x_expand: true });
-        btn_box.add(this.button_add_file, {expand: true});
+        btn_box.add(this.button_add_file);
 
         this.button_cancel = new St.Button({ can_focus: true, label: _('Cancel'), style_class: 'btn-cancel button', x_expand: true });
-        btn_box.add(this.button_cancel, {expand: true});
+        btn_box.add(this.button_cancel);
         this.button_cancel.visible = this.delegate.cache.todo_files.length > 0;
 
         this.button_ok = new St.Button({ can_focus: true, label: _('Ok'), style_class: 'btn-ok button', x_expand: true });
         this.button_ok.visible = this.delegate.cache.todo_files.length > 0;
-        btn_box.add(this.button_ok, {expand: true});
+        btn_box.add(this.button_ok);
 
 
         //
@@ -434,18 +434,18 @@ var FileInfoEditor = class FileInfoEditor {
         // buttons
         //
         let btn_box = new St.BoxLayout({ style_class: 'row btn-box' });
-        this.actor.add(btn_box, {expand: true});
+        this.actor.add(btn_box);
 
         if (file) {
             this.button_delete = new St.Button({ can_focus: true, label: _('Delete'), style_class: 'btn-delete button', x_expand: true });
-            btn_box.add(this.button_delete, {expand: true});
+            btn_box.add(this.button_delete);
             this.button_delete.connect('clicked', () => this.emit('delete'));
         }
 
         this.button_cancel = new St.Button({ can_focus: true, label: _('Cancel'), style_class: 'btn-cancel button', x_expand: true });
         this.button_ok     = new St.Button({ can_focus: true, label: _('Ok'), style_class: 'btn-ok button', x_expand: true });
-        btn_box.add(this.button_cancel, {expand: true});
-        btn_box.add(this.button_ok, {expand: true});
+        btn_box.add(this.button_cancel);
+        btn_box.add(this.button_ok);
         this._update_ok_btn();
 
 

--- a/sections/todo/view__filters.js
+++ b/sections/todo/view__filters.js
@@ -334,10 +334,10 @@ var ViewFilters = class ViewFilters {
 
     _reset_all () {
         if (this.filter_register.completed)
-            this.filter_register.completed.checkbox.actor.checked = false;
+            this.filter_register.completed.checkbox.checked = false;
 
         if (this.filter_register.no_priority)
-            this.filter_register.no_priority.checkbox.actor.checked = false;
+            this.filter_register.no_priority.checkbox.checked = false;
 
         [
             this.filter_register.priorities,
@@ -346,7 +346,7 @@ var ViewFilters = class ViewFilters {
             this.filter_register.custom,
         ].forEach((arr) => {
             for (let i = 0; i < arr.length; i++)
-                arr[i].checkbox.actor.checked = false;
+                arr[i].checkbox.checked = false;
         });
     }
 
@@ -368,9 +368,9 @@ var ViewFilters = class ViewFilters {
         }
 
         item.checkbox = new CheckBox.CheckBox();
-        item.actor.add_actor(item.checkbox.actor);
-        item.checkbox.actor.checked = is_checked;
-        item.checkbox.actor.y_align = St.Align.MIDDLE;
+        item.actor.add_actor(item.checkbox);
+        item.checkbox.checked = is_checked;
+        item.checkbox.y_align = St.Align.MIDDLE;
 
         if (is_deletable) {
             let close_button = new St.Button({ can_focus: true, style_class: 'close-icon' });
@@ -380,14 +380,14 @@ var ViewFilters = class ViewFilters {
             close_button.connect('key-focus-in', () => MISC_UTILS.scroll_to_item(this.filter_sectors_scroll, this.filter_sectors_scroll_box, item.actor, parent_box));
         }
 
-        item.actor.connect('button-press-event', () => { item.checkbox.actor.checked = !item.checkbox.actor.checked; });
-        item.checkbox.actor.connect('key-focus-in', () => MISC_UTILS.scroll_to_item(this.filter_sectors_scroll, this.filter_sectors_scroll_box, item.actor, parent_box));
+        item.actor.connect('button-press-event', () => { item.checkbox.checked = !item.checkbox.checked; });
+        item.checkbox.connect('key-focus-in', () => MISC_UTILS.scroll_to_item(this.filter_sectors_scroll, this.filter_sectors_scroll_box, item.actor, parent_box));
 
         return item;
     }
 
     _delete_custom_item (item) {
-        if (item.checkbox.actor.has_key_focus || close_button.has_key_focus)
+        if (item.checkbox.has_key_focus || close_button.has_key_focus)
             this.entry.entry.grab_key_focus();
 
         item.actor.destroy();
@@ -422,27 +422,27 @@ var ViewFilters = class ViewFilters {
         filters.deferred       = this.show_deferred_tasks_toggle.state;
         filters.recurring      = this.show_recurring_tasks_toggle.state;
         filters.hidden         = this.show_hidden_tasks_toggle.state;
-        filters.completed      = !!(this.filter_register.completed && this.filter_register.completed.checkbox.actor.checked);
-        filters.no_priority    = !!(this.filter_register.no_priority && this.filter_register.no_priority.checkbox.actor.checked);
+        filters.completed      = !!(this.filter_register.completed && this.filter_register.completed.checkbox.checked);
+        filters.no_priority    = !!(this.filter_register.no_priority && this.filter_register.no_priority.checkbox.checked);
 
         for (let i = 0; i < this.filter_register.priorities.length; i++) {
             let it = this.filter_register.priorities[i];
-            if (it.checkbox.actor.checked) filters.priorities.push(it.filter);
+            if (it.checkbox.checked) filters.priorities.push(it.filter);
         }
 
         for (let i = 0; i < this.filter_register.contexts.length; i++) {
             let it = this.filter_register.contexts[i];
-            if (it.checkbox.actor.checked) filters.contexts.push(it.filter);
+            if (it.checkbox.checked) filters.contexts.push(it.filter);
         }
 
         for (let i = 0; i < this.filter_register.projects.length; i++) {
             let it = this.filter_register.projects[i];
-            if (it.checkbox.actor.checked) filters.projects.push(it.filter);
+            if (it.checkbox.checked) filters.projects.push(it.filter);
         }
 
         for (let i = 0; i < this.filter_register.custom.length; i++) {
             let it = this.filter_register.custom[i];
-            if (it.checkbox.actor.checked) filters.custom_active.push(it.filter);
+            if (it.checkbox.checked) filters.custom_active.push(it.filter);
             filters.custom.push(it.filter);
         }
 

--- a/sections/todo/view__filters.js
+++ b/sections/todo/view__filters.js
@@ -112,7 +112,7 @@ var ViewFilters = class ViewFilters {
         this.toggles_sector.add_child(this.show_hidden_tasks_item);
 
         let show_hidden_tasks_label = new St.Label({ text: _('Show hidden tasks only'), y_align: Clutter.ActorAlign.CENTER });
-        this.show_hidden_tasks_item.add(show_hidden_tasks_label, {expand: true});
+        this.show_hidden_tasks_item.add(show_hidden_tasks_label);
 
         let hidden_count_label = new St.Label({ y_align: Clutter.ActorAlign.CENTER, style_class: 'popup-inactive-menu-item', pseudo_class: 'insensitive' });
         this.show_hidden_tasks_item.add_child(hidden_count_label);
@@ -135,7 +135,7 @@ var ViewFilters = class ViewFilters {
         this.toggles_sector.add_child(this.show_recurring_tasks_item);
 
         let show_recurring_tasks_label = new St.Label({ text: _('Show recurring tasks only'), y_align: Clutter.ActorAlign.CENTER });
-        this.show_recurring_tasks_item.add(show_recurring_tasks_label, {expand: true});
+        this.show_recurring_tasks_item.add(show_recurring_tasks_label);
 
         let recurring_count_label = new St.Label({ y_align: Clutter.ActorAlign.CENTER, style_class: 'popup-inactive-menu-item', pseudo_class: 'insensitive' });
         this.show_recurring_tasks_item.add_child(recurring_count_label);
@@ -161,7 +161,7 @@ var ViewFilters = class ViewFilters {
         this.toggles_sector.add_child(this.show_deferred_tasks_item);
 
         let show_deferred_tasks_label = new St.Label({ text: _('Show deferred tasks only'), y_align: Clutter.ActorAlign.CENTER });
-        this.show_deferred_tasks_item.add(show_deferred_tasks_label, {expand: true});
+        this.show_deferred_tasks_item.add(show_deferred_tasks_label);
 
         let deferred_count_label = new St.Label({ y_align: Clutter.ActorAlign.CENTER, style_class: 'popup-inactive-menu-item', pseudo_class: 'insensitive' });
         this.show_deferred_tasks_item.add_child(deferred_count_label);
@@ -186,7 +186,7 @@ var ViewFilters = class ViewFilters {
         this.toggles_sector.add_child(this.invert_item);
 
         let invert_label = new St.Label({ text: _('Invert filters'), y_align: St.Align.END });
-        this.invert_item.add(invert_label, {expand: true});
+        this.invert_item.add(invert_label);
 
         this.invert_toggle_btn = new St.Button({ can_focus: true });
         this.invert_item.add_actor(this.invert_toggle_btn);
@@ -203,8 +203,8 @@ var ViewFilters = class ViewFilters {
         this.button_reset = new St.Button({ can_focus: true, label: _('Reset'), style_class: 'button' });
         this.button_ok    = new St.Button({ can_focus: true, label: _('Ok'), style_class: 'btn-ok button' });
 
-        this.btn_box.add(this.button_reset, {expand: true});
-        this.btn_box.add(this.button_ok, {expand: true});
+        this.btn_box.add(this.button_reset);
+        this.btn_box.add(this.button_ok);
 
 
         //

--- a/sections/todo/view__filters.js
+++ b/sections/todo/view__filters.js
@@ -125,7 +125,7 @@ var ViewFilters = class ViewFilters {
         this.show_hidden_tasks_item.add_actor(this.show_hidden_tasks_toggle_btn);
         this.show_hidden_tasks_toggle = new PopupMenu.Switch();
         this.nand_toggles.push(this.show_hidden_tasks_toggle);
-        this.show_hidden_tasks_toggle_btn.add_actor(this.show_hidden_tasks_toggle.actor);
+        this.show_hidden_tasks_toggle_btn.add_actor(this.show_hidden_tasks_toggle);
 
 
         //
@@ -151,7 +151,7 @@ var ViewFilters = class ViewFilters {
         this.show_recurring_tasks_item.add_actor(this.show_recurring_tasks_toggle_btn);
         this.show_recurring_tasks_toggle = new PopupMenu.Switch();
         this.nand_toggles.push(this.show_recurring_tasks_toggle);
-        this.show_recurring_tasks_toggle_btn.add_actor(this.show_recurring_tasks_toggle.actor);
+        this.show_recurring_tasks_toggle_btn.add_actor(this.show_recurring_tasks_toggle);
 
 
         //
@@ -176,7 +176,7 @@ var ViewFilters = class ViewFilters {
         this.show_deferred_tasks_item.add_actor(this.show_deferred_tasks_toggle_btn);
         this.show_deferred_tasks_toggle = new PopupMenu.Switch();
         this.nand_toggles.push(this.show_deferred_tasks_toggle);
-        this.show_deferred_tasks_toggle_btn.add_actor(this.show_deferred_tasks_toggle.actor);
+        this.show_deferred_tasks_toggle_btn.add_actor(this.show_deferred_tasks_toggle);
 
 
         //
@@ -191,7 +191,7 @@ var ViewFilters = class ViewFilters {
         this.invert_toggle_btn = new St.Button({ can_focus: true });
         this.invert_item.add_actor(this.invert_toggle_btn);
         this.invert_toggle = new PopupMenu.Switch();
-        this.invert_toggle_btn.add_actor(this.invert_toggle.actor);
+        this.invert_toggle_btn.add_actor(this.invert_toggle);
 
 
         //

--- a/sections/todo/view__kanban_switcher.js
+++ b/sections/todo/view__kanban_switcher.js
@@ -89,7 +89,7 @@ var KanbanSwitcher = class KanbanSwitcher {
         this.content_box.add_child(btn_box);
 
         this.button_cancel = new St.Button({ can_focus: true, label: _('Cancel'), style_class: 'btn-cancel button', x_expand: true });
-        btn_box.add(this.button_cancel, {expand: true});
+        btn_box.add(this.button_cancel);
         this.button_cancel.visible = this.delegate.cache.todo_files.length > 0;
 
 

--- a/sections/todo/view__search.js
+++ b/sections/todo/view__search.js
@@ -79,7 +79,7 @@ var ViewSearch = class ViewSearch {
         // task items box
         //
         this.tasks_scroll = new St.ScrollView({ style_class: 'timepp-menu-item tasks-container vfade search-results', x_fill: true, y_align: St.Align.START});
-        this.content_box.add(this.tasks_scroll, {expand: true});
+        this.content_box.add(this.tasks_scroll);
         this.tasks_scroll.hscrollbar_policy = Gtk.PolicyType.NEVER;
 
         this.tasks_scroll_content = new St.BoxLayout({ vertical: true, style_class: 'tasks-content-box'});

--- a/sections/todo/view__sort.js
+++ b/sections/todo/view__sort.js
@@ -98,7 +98,7 @@ var ViewSort = class ViewSort {
         this.toggle_automatic_sort_btn = new St.Button({ can_focus: true });
         this.toggle_automatic_sort.add_actor(this.toggle_automatic_sort_btn);
         this.toggle = new PopupMenu.Switch();
-        this.toggle_automatic_sort_btn.add_actor(this.toggle.actor);
+        this.toggle_automatic_sort_btn.add_actor(this.toggle);
         this.toggle.setToggleState(this.delegate.get_current_todo_file().automatic_sort);
 
 

--- a/sections/todo/view__sort.js
+++ b/sections/todo/view__sort.js
@@ -108,7 +108,7 @@ var ViewSort = class ViewSort {
         this.btn_box = new St.BoxLayout({ x_expand: true, style_class: 'row btn-box' });
         this.content_box.add_child(this.btn_box);
         this.button_ok = new St.Button({ can_focus: true, label: _('Ok'), style_class: 'btn-ok button' });
-        this.btn_box.add(this.button_ok, {expand: true});
+        this.btn_box.add(this.button_ok);
 
 
         //

--- a/sections/todo/view__task_editor.js
+++ b/sections/todo/view__task_editor.js
@@ -203,7 +203,7 @@ var ViewTaskEditor = class ViewTaskEditor {
 
         if (this.mode === EditorMode.EDIT_TASK) {
             this.button_delete = new St.Button({ can_focus: true, label: _('Delete'), style_class: 'btn-delete button', x_expand: true });
-            this.btn_box.add(this.button_delete, {expand: true});
+            this.btn_box.add(this.button_delete);
             this.button_delete.connect('clicked', () => this.emit('delete-task'));
         }
 
@@ -211,15 +211,15 @@ var ViewTaskEditor = class ViewTaskEditor {
 
         if (this.mode === EditorMode.EDIT_TASK && current && current.done_file && !task.hidden) {
             this.button_archive = new St.Button({ can_focus: true, label: _('Archive'), style_class: 'btn-delete button', x_expand: true });
-            this.btn_box.add(this.button_archive, {expand: true});
+            this.btn_box.add(this.button_archive);
             this.button_archive.connect('clicked', () => this.emit('delete-task', true));
         }
 
         this.button_cancel = new St.Button({ can_focus: true, label: _('Cancel'), style_class: 'btn-cancel button', x_expand: true });
-        this.btn_box.add(this.button_cancel, {expand: true});
+        this.btn_box.add(this.button_cancel);
 
         this.button_ok = new St.Button({ can_focus: true, label: _('Ok'), style_class: 'btn-ok button', x_expand: true });
-        this.btn_box.add(this.button_ok, {expand: true});
+        this.btn_box.add(this.button_ok);
 
 
         //


### PR DESCRIPTION
- Removed/replaced deprecated calls (fix #133)
- Fixed notifications
- Fixed crash related to theme loading (fix #104 #126)*
- Better handle of Clutter.Actor destroy

\* Side effect: top panel may flash because an empty theme must be loaded to clean all theme nodes (needed to avoid crash)
\* Reference for try/catch code (@tuberry): https://github.com/tuberry/user-theme-x/blob/3b188849c84709734a190418b023b5b5e6d5578c/user-theme-x%40tuberry.github.io/extension.js#L39

PS: I haven't tested the whole app, but there are no more errors loading/unloading the extension and with screen lock/suspend.