### PR TITLE
Fix extension settings are crashing

### DIFF
--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -430,7 +430,7 @@
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
-                                                <signal name="clicked" handler="_onBtnClicked" swapped="no"/>
+                                                <signal name="clicked" handler="on_button_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1083,7 +1083,7 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
-                                                <signal name="clicked" handler="_onBtnClicked" swapped="no"/>
+                                                <signal name="clicked" handler="on_button_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1120,7 +1120,7 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
-                                                <signal name="clicked" handler="_onBtnClicked" swapped="no"/>
+                                                <signal name="clicked" handler="on_button_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1157,7 +1157,7 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
-                                                <signal name="clicked" handler="_onBtnClicked" swapped="no"/>
+                                                <signal name="clicked" handler="on_button_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1360,7 +1360,7 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
-                                                <signal name="clicked" handler="_onBtnClicked" swapped="no"/>
+                                                <signal name="clicked" handler="on_button_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -429,7 +429,7 @@
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
-                                                <signal name="clicked" handler="on_button_click" swapped="no"/>
+                                                <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1081,7 +1081,7 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
-                                                <signal name="clicked" handler="on_button_click" swapped="no"/>
+                                                <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1117,7 +1117,7 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
-                                                <signal name="clicked" handler="on_button_click" swapped="no"/>
+                                                <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1153,7 +1153,7 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
-                                                <signal name="clicked" handler="on_button_click" swapped="no"/>
+                                                <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1355,7 +1355,7 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
-                                                <signal name="clicked" handler="on_button_click" swapped="no"/>
+                                                <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -1647,7 +1647,6 @@ F3</property>
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
-                                <property name="label_yalign">0</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -1965,4 +1965,11 @@ F3</property>
       </object>
     </child>
   </object>
+  <object class="GtkFileChooserNative" id="file_chooser">
+        <property name="title" translatable="yes">Choose File</property>
+        <property name="select-multiple">0</property>
+        <property name="action">open</property>
+        <property name="modal">1</property>
+        <signal name="response" handler="on_file_chooser_response" swapped="no"/>
+    </object>
 </interface>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -10,11 +10,9 @@
   <object class="GtkBox" id="settings_widget">
     <property name="width_request">800</property>
     <property name="height_request">500</property>
-    <property name="can_focus">0</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkStack" id="settings_stack">
-        <property name="can_focus">0</property>
         <property name="vexpand">1</property>
         <property name="transition_type">slide-left-right</property>
         <property name="interpolate_size">1</property>
@@ -24,7 +22,6 @@
             <property name="title" translatable="yes">General</property>
             <property name="child">
               <object class="GtkBox">
-                <property name="can_focus">0</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow">
@@ -32,10 +29,8 @@
                     <property name="vexpand">1</property>
                     <property name="child">
                       <object class="GtkViewport">
-                        <property name="can_focus">0</property>
                         <property name="child">
                           <object class="GtkBox">
-                            <property name="can_focus">0</property>
                             <property name="margin-start">100</property>
                             <property name="margin-end">100</property>
                             <property name="margin_top">20</property>
@@ -45,11 +40,9 @@
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
@@ -58,14 +51,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show only 1 panel icon for joined menus</property>
@@ -86,14 +77,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Position in the panel</property>
@@ -101,7 +90,6 @@
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="panel-item-position-combo">
-                                                <property name="can_focus">0</property>
                                                 <property name="active">2</property>
                                                 <items>
                                                   <item translatable="yes">Left</item>
@@ -123,7 +111,6 @@
                             </child>
                             <child>
                               <object class="GtkLabel">
-                                <property name="can_focus">0</property>
                                 <property name="halign">start</property>
                                 <property name="valign">baseline</property>
                                 <property name="label" translatable="yes">Enabled Sections</property>
@@ -134,10 +121,8 @@
                             </child>
                             <child>
                               <object class="GtkFrame">
-                                <property name="can_focus">0</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
@@ -146,14 +131,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Timer</property>
@@ -174,14 +157,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Stopwatch</property>
@@ -202,14 +183,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Pomodoro</property>
@@ -230,14 +209,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Alarms</property>
@@ -258,14 +235,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Todo and Time Tracker</property>
@@ -301,7 +276,6 @@
             <property name="title" translatable="yes">Timer</property>
             <property name="child">
               <object class="GtkBox">
-                <property name="can_focus">0</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow">
@@ -309,10 +283,8 @@
                     <property name="vexpand">1</property>
                     <property name="child">
                       <object class="GtkViewport">
-                        <property name="can_focus">0</property>
                         <property name="child">
                           <object class="GtkBox">
-                            <property name="can_focus">0</property>
                             <property name="margin-start">100</property>
                             <property name="margin-end">100</property>
                             <property name="margin_top">20</property>
@@ -322,11 +294,9 @@
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
@@ -335,14 +305,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show in separate menu</property>
@@ -363,14 +331,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show seconds</property>
@@ -391,14 +357,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Panel Item Mode</property>
@@ -406,7 +370,6 @@
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="timer-panel-mode-combo">
-                                                <property name="can_focus">0</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item translatable="yes">Icon only</item>
@@ -428,7 +391,6 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
@@ -436,7 +398,6 @@
                                             <property name="spacing">16</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Notification sound</property>
@@ -449,7 +410,6 @@
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="timer-sound-button">
-                                                <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes">Open</property>
@@ -467,14 +427,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Notification style</property>
@@ -482,7 +440,6 @@
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="timer-notif-style-combo">
-                                                <property name="can_focus">0</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item translatable="yes">Standard</item>
@@ -504,7 +461,6 @@
                             </child>
                             <child>
                               <object class="GtkLabel">
-                                <property name="can_focus">0</property>
                                 <property name="halign">start</property>
                                 <property name="valign">baseline</property>
                                 <property name="label" translatable="yes">Keyboard shortcuts</property>
@@ -516,10 +472,8 @@
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
@@ -528,14 +482,12 @@
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu</property>
@@ -563,14 +515,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open in fullscreen</property>
@@ -598,14 +548,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu and search presets</property>
@@ -648,7 +596,6 @@ F3</property>
             <property name="title" translatable="yes">Stopwatch</property>
             <property name="child">
               <object class="GtkBox">
-                <property name="can_focus">0</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow">
@@ -656,10 +603,8 @@ F3</property>
                     <property name="vexpand">1</property>
                     <property name="child">
                       <object class="GtkViewport">
-                        <property name="can_focus">0</property>
                         <property name="child">
                           <object class="GtkBox">
-                            <property name="can_focus">0</property>
                             <property name="margin-start">100</property>
                             <property name="margin-end">100</property>
                             <property name="margin_top">20</property>
@@ -669,11 +614,9 @@ F3</property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
@@ -682,14 +625,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show in separate menu</property>
@@ -710,14 +651,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Format</property>
@@ -725,7 +664,6 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="stopwatch-clock-format-combo">
-                                                <property name="can_focus">0</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item translatable="yes">hours:min</item>
@@ -746,14 +684,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Panel Item Mode</property>
@@ -761,7 +697,6 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="stopwatch-panel-mode-combo">
-                                                <property name="can_focus">0</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item translatable="yes">Icon only</item>
@@ -784,7 +719,6 @@ F3</property>
                             </child>
                             <child>
                               <object class="GtkLabel">
-                                <property name="can_focus">0</property>
                                 <property name="halign">start</property>
                                 <property name="valign">baseline</property>
                                 <property name="label" translatable="yes">Keyboard shortcuts</property>
@@ -796,10 +730,8 @@ F3</property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
@@ -808,14 +740,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu</property>
@@ -843,14 +773,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open in fullscreen</property>
@@ -893,7 +821,6 @@ F3</property>
             <property name="title" translatable="yes">Pomodoro</property>
             <property name="child">
               <object class="GtkBox">
-                <property name="can_focus">0</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow">
@@ -901,10 +828,8 @@ F3</property>
                     <property name="vexpand">1</property>
                     <property name="child">
                       <object class="GtkViewport">
-                        <property name="can_focus">0</property>
                         <property name="child">
                           <object class="GtkBox">
-                            <property name="can_focus">0</property>
                             <property name="margin-start">100</property>
                             <property name="margin-end">100</property>
                             <property name="margin_top">20</property>
@@ -914,11 +839,9 @@ F3</property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
@@ -927,14 +850,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show in separate menu</property>
@@ -955,14 +876,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show seconds</property>
@@ -983,14 +902,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Panel Item Mode</property>
@@ -998,7 +915,6 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="pomodoro-panel-mode-combo">
-                                                <property name="can_focus">0</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item translatable="yes">Icon only</item>
@@ -1020,14 +936,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Notification style</property>
@@ -1035,7 +949,6 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="pomodoro-notif-style-combo">
-                                                <property name="can_focus">0</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item translatable="yes">Standard</item>
@@ -1057,7 +970,6 @@ F3</property>
                             </child>
                             <child>
                               <object class="GtkLabel">
-                                <property name="can_focus">0</property>
                                 <property name="halign">start</property>
                                 <property name="valign">baseline</property>
                                 <property name="label" translatable="yes">Notification Sounds</property>
@@ -1069,11 +981,9 @@ F3</property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
@@ -1082,7 +992,6 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
@@ -1090,7 +999,6 @@ F3</property>
                                             <property name="spacing">16</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Repeat notification sound?</property>
@@ -1111,7 +1019,6 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
@@ -1119,7 +1026,6 @@ F3</property>
                                             <property name="spacing">16</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Pomodoro</property>
@@ -1132,7 +1038,6 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="pomodoro-sound-button-pomo">
-                                                <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes">Open</property>
@@ -1150,7 +1055,6 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
@@ -1158,7 +1062,6 @@ F3</property>
                                             <property name="spacing">16</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Short Break</property>
@@ -1171,7 +1074,6 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="pomodoro-sound-button-short-break">
-                                                <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes">Open</property>
@@ -1189,7 +1091,6 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
@@ -1197,7 +1098,6 @@ F3</property>
                                             <property name="spacing">16</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Long Break</property>
@@ -1210,7 +1110,6 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="pomodoro-sound-button-long-break">
-                                                <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes">Open</property>
@@ -1229,7 +1128,6 @@ F3</property>
                             </child>
                             <child>
                               <object class="GtkLabel">
-                                <property name="can_focus">0</property>
                                 <property name="halign">start</property>
                                 <property name="valign">baseline</property>
                                 <property name="label" translatable="yes">Keyboard shortcuts</property>
@@ -1241,10 +1139,8 @@ F3</property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
@@ -1253,14 +1149,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu</property>
@@ -1288,14 +1182,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open in fullscreen</property>
@@ -1338,7 +1230,6 @@ F3</property>
             <property name="title" translatable="yes">Alarms</property>
             <property name="child">
               <object class="GtkBox">
-                <property name="can_focus">0</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow">
@@ -1346,10 +1237,8 @@ F3</property>
                     <property name="vexpand">1</property>
                     <property name="child">
                       <object class="GtkViewport">
-                        <property name="can_focus">0</property>
                         <property name="child">
                           <object class="GtkBox">
-                            <property name="can_focus">0</property>
                             <property name="margin-start">100</property>
                             <property name="margin-end">100</property>
                             <property name="margin_top">20</property>
@@ -1359,11 +1248,9 @@ F3</property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
@@ -1372,14 +1259,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show in separate menu</property>
@@ -1400,7 +1285,6 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
@@ -1408,7 +1292,6 @@ F3</property>
                                             <property name="spacing">16</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Notification sound</property>
@@ -1421,7 +1304,6 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="alarms-sound-button">
-                                                <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes">Open</property>
@@ -1439,14 +1321,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Notification style</property>
@@ -1454,7 +1334,6 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="alarms-notif-style-combo">
-                                                <property name="can_focus">0</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item translatable="yes">Standard</item>
@@ -1476,7 +1355,6 @@ F3</property>
                             </child>
                             <child>
                               <object class="GtkLabel">
-                                <property name="can_focus">0</property>
                                 <property name="halign">start</property>
                                 <property name="valign">baseline</property>
                                 <property name="label" translatable="yes">Keyboard shortcuts</property>
@@ -1488,10 +1366,8 @@ F3</property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
@@ -1500,14 +1376,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu</property>
@@ -1550,7 +1424,6 @@ F3</property>
             <property name="title" translatable="yes">Todo / Time Tracker</property>
             <property name="child">
               <object class="GtkBox">
-                <property name="can_focus">0</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow">
@@ -1558,10 +1431,8 @@ F3</property>
                     <property name="vexpand">1</property>
                     <property name="child">
                       <object class="GtkViewport">
-                        <property name="can_focus">0</property>
                         <property name="child">
                           <object class="GtkBox">
-                            <property name="can_focus">0</property>
                             <property name="margin-start">100</property>
                             <property name="margin-end">100</property>
                             <property name="margin_top">20</property>
@@ -1571,11 +1442,9 @@ F3</property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <property name="activate_on_single_click">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
@@ -1585,14 +1454,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show in separate menu</property>
@@ -1613,14 +1480,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Panel Item Mode</property>
@@ -1628,7 +1493,6 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="todo-panel-mode-combo">
-                                                <property name="can_focus">0</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item translatable="yes">Icon only</item>
@@ -1649,14 +1513,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Task width (px)</property>
@@ -1683,14 +1545,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Resume tracking after abrupt restart?</property>
@@ -1714,7 +1574,6 @@ F3</property>
                             </child>
                             <child>
                               <object class="GtkLabel">
-                                <property name="can_focus">0</property>
                                 <property name="halign">start</property>
                                 <property name="valign">baseline</property>
                                 <property name="label" translatable="yes">Keyboard shortcuts</property>
@@ -1726,11 +1585,9 @@ F3</property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
-                                <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
                                 <property name="child">
                                   <object class="GtkListBox">
-                                    <property name="can_focus">0</property>
                                     <property name="activate_on_single_click">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
@@ -1740,14 +1597,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu</property>
@@ -1775,14 +1630,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu and add task</property>
@@ -1810,14 +1663,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu and search tasks</property>
@@ -1851,14 +1702,12 @@ F3</property>
                                             <property name="selectable">0</property>
                                             <property name="child">
                                               <object class="GtkBox">
-                                                <property name="can_focus">0</property>
                                                 <property name="margin-start">10</property>
                                                 <property name="margin-end">10</property>
                                                 <property name="margin_top">10</property>
                                                 <property name="margin_bottom">10</property>
                                                 <child>
                                                   <object class="GtkLabel">
-                                                    <property name="can_focus">0</property>
                                                     <property name="hexpand">1</property>
                                                     <property name="halign">start</property>
                                                     <property name="label" translatable="yes">Open popup menu and switch todo files</property>
@@ -1888,14 +1737,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open stats view</property>
@@ -1923,14 +1770,12 @@ F3</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkBox">
-                                            <property name="can_focus">0</property>
                                             <property name="margin-start">10</property>
                                             <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open current todo.txt file</property>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -425,8 +425,7 @@
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="timer-sound-button">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
@@ -1078,8 +1077,7 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="pomodoro-sound-button-pomo">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
@@ -1115,8 +1113,7 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="pomodoro-sound-button-short-break">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
@@ -1152,8 +1149,7 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="pomodoro-sound-button-long-break">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>
@@ -1355,8 +1351,7 @@ F3</property>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="alarms-sound-button">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes"></property>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -450,7 +450,7 @@
                                                 <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
-                                                <property name="label" translatable="yes"></property>
+                                                <property name="label" translatable="yes">Open</property>
                                                 <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
@@ -1132,7 +1132,7 @@ F3</property>
                                                 <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
-                                                <property name="label" translatable="yes"></property>
+                                                <property name="label" translatable="yes">Open</property>
                                                 <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
@@ -1170,7 +1170,7 @@ F3</property>
                                                 <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
-                                                <property name="label" translatable="yes"></property>
+                                                <property name="label" translatable="yes">Open</property>
                                                 <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
@@ -1208,7 +1208,7 @@ F3</property>
                                                 <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
-                                                <property name="label" translatable="yes"></property>
+                                                <property name="label" translatable="yes">Open</property>
                                                 <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
@@ -1418,7 +1418,7 @@ F3</property>
                                                 <property name="can_focus">0</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
-                                                <property name="label" translatable="yes"></property>
+                                                <property name="label" translatable="yes">Open</property>
                                                 <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -66,6 +66,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">1</property>
                                                 <property name="label" translatable="yes">Show only 1 panel icon for joined menus</property>
                                               </object>
                                             </child>
@@ -92,6 +94,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">1</property>
                                                 <property name="label" translatable="yes">Position in the panel</property>
                                               </object>
                                             </child>
@@ -150,6 +154,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">1</property>
                                                 <property name="label" translatable="yes">Timer</property>
                                               </object>
                                             </child>
@@ -176,6 +182,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">1</property>
                                                 <property name="label" translatable="yes">Stopwatch</property>
                                               </object>
                                             </child>
@@ -202,6 +210,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">1</property>
                                                 <property name="label" translatable="yes">Pomodoro</property>
                                               </object>
                                             </child>
@@ -228,6 +238,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">1</property>
                                                 <property name="label" translatable="yes">Alarms</property>
                                               </object>
                                             </child>
@@ -254,6 +266,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">1</property>
                                                 <property name="label" translatable="yes">Todo and Time Tracker</property>
                                               </object>
                                             </child>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -47,7 +47,6 @@
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -132,7 +131,6 @@
                             <child>
                               <object class="GtkFrame">
                                 <property name="can_focus">0</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -313,7 +311,6 @@
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -498,7 +495,6 @@
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -648,7 +644,6 @@ F3</property>
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -769,7 +764,6 @@ F3</property>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -886,7 +880,6 @@ F3</property>
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -1034,7 +1027,6 @@ F3</property>
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -1201,7 +1193,6 @@ F3</property>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -1318,7 +1309,6 @@ F3</property>
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -1442,7 +1432,6 @@ F3</property>
                               <object class="GtkFrame">
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -1526,7 +1515,6 @@ F3</property>
                                 <property name="valign">center</property>
                                 <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>
@@ -1676,7 +1664,6 @@ F3</property>
                                 <property name="can_focus">0</property>
                                 <property name="margin_bottom">12</property>
                                 <property name="label_yalign">0</property>
-                                <property name="shadow_type">in</property>
                                 <property name="child">
                                   <object class="GtkListBox">
                                     <property name="can_focus">0</property>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -285,7 +285,6 @@
           <object class="GtkStackPage">
             <property name="name">page1</property>
             <property name="title" translatable="yes">Timer</property>
-            <property name="position">1</property>
             <property name="child">
               <object class="GtkBox">
                 <property name="can_focus">0</property>
@@ -618,7 +617,6 @@ F3</property>
           <object class="GtkStackPage">
             <property name="name">page2</property>
             <property name="title" translatable="yes">Stopwatch</property>
-            <property name="position">2</property>
             <property name="child">
               <object class="GtkBox">
                 <property name="can_focus">0</property>
@@ -854,7 +852,6 @@ F3</property>
           <object class="GtkStackPage">
             <property name="name">page3</property>
             <property name="title" translatable="yes">Pomodoro</property>
-            <property name="position">3</property>
             <property name="child">
               <object class="GtkBox">
                 <property name="can_focus">0</property>
@@ -1283,7 +1280,6 @@ F3</property>
           <object class="GtkStackPage">
             <property name="name">page4</property>
             <property name="title" translatable="yes">Alarms</property>
-            <property name="position">4</property>
             <property name="child">
               <object class="GtkBox">
                 <property name="can_focus">0</property>
@@ -1489,7 +1485,6 @@ F3</property>
           <object class="GtkStackPage">
             <property name="name">page5</property>
             <property name="title" translatable="yes">Todo / Time Tracker</property>
-            <property name="position">5</property>
             <property name="child">
               <object class="GtkBox">
                 <property name="can_focus">0</property>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -45,6 +45,7 @@
                                   <object class="GtkListBox">
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -71,6 +72,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -125,6 +127,7 @@
                                   <object class="GtkListBox">
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -151,6 +154,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -177,6 +181,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -203,6 +208,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -229,6 +235,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -299,6 +306,7 @@
                                   <object class="GtkListBox">
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -325,6 +333,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -351,6 +360,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -385,6 +395,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -421,6 +432,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -476,6 +488,7 @@
                                   <object class="GtkListBox">
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -509,6 +522,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -542,6 +556,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -619,6 +634,7 @@ F3</property>
                                   <object class="GtkListBox">
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -645,6 +661,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -678,6 +695,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -734,6 +752,7 @@ F3</property>
                                   <object class="GtkListBox">
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -767,6 +786,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -844,6 +864,7 @@ F3</property>
                                   <object class="GtkListBox">
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -870,6 +891,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -896,6 +918,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -930,6 +953,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -986,6 +1010,7 @@ F3</property>
                                   <object class="GtkListBox">
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1013,6 +1038,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1049,6 +1075,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1085,6 +1112,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1143,6 +1171,7 @@ F3</property>
                                   <object class="GtkListBox">
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1176,6 +1205,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1253,6 +1283,7 @@ F3</property>
                                   <object class="GtkListBox">
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1279,6 +1310,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1315,6 +1347,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1370,6 +1403,7 @@ F3</property>
                                   <object class="GtkListBox">
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1448,6 +1482,7 @@ F3</property>
                                     <property name="activate_on_single_click">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1474,6 +1509,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1507,6 +1543,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1539,6 +1576,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1591,6 +1629,7 @@ F3</property>
                                     <property name="activate_on_single_click">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1624,6 +1663,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1657,6 +1697,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1690,12 +1731,14 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
                                         <property name="selectable">0</property>
                                         <property name="child">
                                           <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                             <property name="width_request">100</property>
                                             <property name="height_request">40</property>
                                             <property name="activatable">0</property>
@@ -1731,6 +1774,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>
@@ -1764,6 +1808,7 @@ F3</property>
                                     </child>
                                     <child>
                                       <object class="GtkListBoxRow">
+                                        <property name="focusable">0</property>
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
                                         <property name="activatable">0</property>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -443,7 +443,9 @@
                                               </object>
                                             </child>
                                             <child>
-                                              <object class="GtkSwitch" id="timer-play-sound-switch"/>
+                                              <object class="GtkSwitch" id="timer-play-sound-switch">
+                                                <property name="valign">center</property>
+                                              </object>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="timer-sound-button">
@@ -1125,7 +1127,9 @@ F3</property>
                                               </object>
                                             </child>
                                             <child>
-                                              <object class="GtkSwitch" id="pomodoro-play-sound-switch-pomo"/>
+                                              <object class="GtkSwitch" id="pomodoro-play-sound-switch-pomo">
+                                                <property name="valign">center</property>
+                                              </object>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="pomodoro-sound-button-pomo">
@@ -1163,7 +1167,9 @@ F3</property>
                                               </object>
                                             </child>
                                             <child>
-                                              <object class="GtkSwitch" id="pomodoro-play-sound-switch-short-break"/>
+                                              <object class="GtkSwitch" id="pomodoro-play-sound-switch-short-break">
+                                                <property name="valign">center</property>
+                                              </object>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="pomodoro-sound-button-short-break">
@@ -1201,7 +1207,9 @@ F3</property>
                                               </object>
                                             </child>
                                             <child>
-                                              <object class="GtkSwitch" id="pomodoro-play-sound-switch-long-break"/>
+                                              <object class="GtkSwitch" id="pomodoro-play-sound-switch-long-break">
+                                                <property name="valign">center</property>
+                                              </object>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="pomodoro-sound-button-long-break">
@@ -1411,7 +1419,9 @@ F3</property>
                                               </object>
                                             </child>
                                             <child>
-                                              <object class="GtkSwitch" id="alarms-play-sound-switch"/>
+                                              <object class="GtkSwitch" id="alarms-play-sound-switch">
+                                                <property name="valign">center</property>
+                                              </object>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="alarms-sound-button">

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -424,11 +424,13 @@
                                               <object class="GtkSwitch" id="timer-play-sound-switch"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserNative" id="timer-sound-chooser">
+                                              <object class="GtkFileChooserButton" id="timer-sound-chooser">
                                                 <property name="visible">True</property>
-                                                <property name="select-multiple">0</property>
-                                                <property name="action">open</property>
-                                                <property name="modal">1</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="preview_widget_active">False</property>
+                                                <property name="use_preview_label">False</property>
                                                 <property name="title" translatable="yes"></property>
                                               </object>
                                             </child>
@@ -1076,11 +1078,13 @@ F3</property>
                                               <object class="GtkSwitch" id="pomodoro-play-sound-switch-pomo"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserNative" id="pomodoro-sound-chooser-pomo">
+                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-pomo">
                                                 <property name="visible">True</property>
-                                                <property name="select-multiple">0</property>
-                                                <property name="action">open</property>
-                                                <property name="modal">1</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="preview_widget_active">False</property>
+                                                <property name="use_preview_label">False</property>
                                                 <property name="title" translatable="yes"></property>
                                               </object>
                                             </child>
@@ -1112,11 +1116,13 @@ F3</property>
                                               <object class="GtkSwitch" id="pomodoro-play-sound-switch-short-break"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserNative" id="pomodoro-sound-chooser-short-break">
+                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-short-break">
                                                 <property name="visible">True</property>
-                                                <property name="select-multiple">0</property>
-                                                <property name="action">open</property>
-                                                <property name="modal">1</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="preview_widget_active">False</property>
+                                                <property name="use_preview_label">False</property>
                                                 <property name="title" translatable="yes"></property>
                                               </object>
                                             </child>
@@ -1148,11 +1154,13 @@ F3</property>
                                               <object class="GtkSwitch" id="pomodoro-play-sound-switch-long-break"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserNative" id="pomodoro-sound-chooser-long-break">
+                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-long-break">
                                                 <property name="visible">True</property>
-                                                <property name="select-multiple">0</property>
-                                                <property name="action">open</property>
-                                                <property name="modal">1</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="preview_widget_active">False</property>
+                                                <property name="use_preview_label">False</property>
                                                 <property name="title" translatable="yes"></property>
                                               </object>
                                             </child>
@@ -1350,11 +1358,13 @@ F3</property>
                                               <object class="GtkSwitch" id="alarms-play-sound-switch"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserNative" id="alarms-sound-chooser">
+                                              <object class="GtkFileChooserButton" id="alarms-sound-chooser">
                                                 <property name="visible">True</property>
-                                                <property name="select-multiple">0</property>
-                                                <property name="action">open</property>
-                                                <property name="modal">1</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="preview_widget_active">False</property>
+                                                <property name="use_preview_label">False</property>
                                                 <property name="title" translatable="yes"></property>
                                               </object>
                                             </child>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -453,7 +453,6 @@
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes">Open</property>
-                                                <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1137,7 +1136,6 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes">Open</property>
-                                                <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1177,7 +1175,6 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes">Open</property>
-                                                <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1217,7 +1214,6 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes">Open</property>
-                                                <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1429,7 +1425,6 @@ F3</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
                                                 <property name="label" translatable="yes">Open</property>
-                                                <signal name="clicked" handler="on_btn_click" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1976,10 +1971,9 @@ F3</property>
     </child>
   </object>
   <object class="GtkFileChooserNative" id="file_chooser">
-        <property name="title" translatable="yes">Choose File</property>
-        <property name="select-multiple">0</property>
-        <property name="action">open</property>
-        <property name="modal">1</property>
-        <signal name="response" handler="on_file_chooser_response" swapped="no"/>
-    </object>
+    <property name="title" translatable="yes">Choose File</property>
+    <property name="select-multiple">0</property>
+    <property name="action">open</property>
+    <property name="modal">1</property>
+  </object>
 </interface>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -67,7 +67,7 @@
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
-                                                <property name="halign">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show only 1 panel icon for joined menus</property>
                                               </object>
                                             </child>
@@ -95,7 +95,7 @@
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
-                                                <property name="halign">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Position in the panel</property>
                                               </object>
                                             </child>
@@ -155,7 +155,7 @@
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
-                                                <property name="halign">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Timer</property>
                                               </object>
                                             </child>
@@ -183,7 +183,7 @@
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
-                                                <property name="halign">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Stopwatch</property>
                                               </object>
                                             </child>
@@ -211,7 +211,7 @@
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
-                                                <property name="halign">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Pomodoro</property>
                                               </object>
                                             </child>
@@ -239,7 +239,7 @@
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
-                                                <property name="halign">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Alarms</property>
                                               </object>
                                             </child>
@@ -267,7 +267,7 @@
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
                                                 <property name="hexpand">1</property>
-                                                <property name="halign">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Todo and Time Tracker</property>
                                               </object>
                                             </child>
@@ -343,6 +343,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show in separate menu</property>
                                               </object>
                                             </child>
@@ -369,6 +371,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show seconds</property>
                                               </object>
                                             </child>
@@ -395,6 +399,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Panel Item Mode</property>
                                               </object>
                                             </child>
@@ -431,6 +437,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Notification sound</property>
                                               </object>
                                             </child>
@@ -466,6 +474,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Notification style</property>
                                               </object>
                                             </child>
@@ -525,6 +535,8 @@
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu</property>
                                               </object>
                                             </child>
@@ -558,6 +570,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open in fullscreen</property>
                                               </object>
                                             </child>
@@ -591,6 +605,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu and search presets</property>
                                               </object>
                                             </child>
@@ -673,6 +689,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show in separate menu</property>
                                               </object>
                                             </child>
@@ -699,6 +717,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Format</property>
                                               </object>
                                             </child>
@@ -733,6 +753,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Panel Item Mode</property>
                                               </object>
                                             </child>
@@ -793,6 +815,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu</property>
                                               </object>
                                             </child>
@@ -826,6 +850,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open in fullscreen</property>
                                               </object>
                                             </child>
@@ -908,6 +934,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show in separate menu</property>
                                               </object>
                                             </child>
@@ -934,6 +962,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show seconds</property>
                                               </object>
                                             </child>
@@ -960,6 +990,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Panel Item Mode</property>
                                               </object>
                                             </child>
@@ -995,6 +1027,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Notification style</property>
                                               </object>
                                             </child>
@@ -1056,6 +1090,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Repeat notification sound?</property>
                                               </object>
                                             </child>
@@ -1083,6 +1119,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Pomodoro</property>
                                               </object>
                                             </child>
@@ -1119,6 +1157,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Short Break</property>
                                               </object>
                                             </child>
@@ -1155,6 +1195,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Long Break</property>
                                               </object>
                                             </child>
@@ -1215,6 +1257,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu</property>
                                               </object>
                                             </child>
@@ -1248,6 +1292,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open in fullscreen</property>
                                               </object>
                                             </child>
@@ -1330,6 +1376,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show in separate menu</property>
                                               </object>
                                             </child>
@@ -1357,6 +1405,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Notification sound</property>
                                               </object>
                                             </child>
@@ -1392,6 +1442,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Notification style</property>
                                               </object>
                                             </child>
@@ -1451,6 +1503,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu</property>
                                               </object>
                                             </child>
@@ -1534,6 +1588,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Show in separate menu</property>
                                               </object>
                                             </child>
@@ -1560,6 +1616,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Panel Item Mode</property>
                                               </object>
                                             </child>
@@ -1592,18 +1650,20 @@ F3</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">Task width (px)</property>
+                                              </object>
+                                            </child>
+                                            <child>
                                               <object class="GtkSpinButton" id="todo-task-width-spin">
                                                 <property name="text">0</property>
                                                 <property name="adjustment">todo-width-spin-adjustment</property>
                                                 <property name="climb_rate">1</property>
                                                 <property name="numeric">1</property>
                                                 <property name="value">200</property>
-                                              </object>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
-                                                <property name="label" translatable="yes">Task width (px)</property>
                                               </object>
                                             </child>
                                           </object>
@@ -1626,6 +1686,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Resume tracking after abrupt restart?</property>
                                               </object>
                                             </child>
@@ -1681,6 +1743,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu</property>
                                               </object>
                                             </child>
@@ -1714,6 +1778,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open popup menu and add task</property>
                                               </object>
                                             </child>
@@ -1745,6 +1811,14 @@ F3</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">Open popup menu and search tasks</property>
+                                              </object>
+                                            </child>
+                                            <child>
                                               <object class="GtkEntry" id="todo-keybinding-open-to-search">
                                                 <property name="tooltip_text" translatable="yes">Examples:
 &lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
@@ -1752,12 +1826,6 @@ F3</property>
 F3</property>
                                                 <property name="truncate_multiline">1</property>
                                                 <property name="placeholder_text" translatable="yes">not set</property>
-                                              </object>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
-                                                <property name="label" translatable="yes">Open popup menu and search tasks</property>
                                               </object>
                                             </child>
                                           </object>
@@ -1784,6 +1852,14 @@ F3</property>
                                                 <property name="margin_top">10</property>
                                                 <property name="margin_bottom">10</property>
                                                 <child>
+                                                  <object class="GtkLabel">
+                                                    <property name="can_focus">0</property>
+                                                    <property name="hexpand">1</property>
+                                                    <property name="halign">start</property>
+                                                    <property name="label" translatable="yes">Open popup menu and switch todo files</property>
+                                                  </object>
+                                                </child>
+                                                <child>
                                                   <object class="GtkEntry" id="todo-keybinding-open-to-switch-files">
                                                     <property name="tooltip_text" translatable="yes">Examples:
 &lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
@@ -1791,12 +1867,6 @@ F3</property>
 F3</property>
                                                     <property name="truncate_multiline">1</property>
                                                     <property name="placeholder_text" translatable="yes">not set</property>
-                                                  </object>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel">
-                                                    <property name="can_focus">0</property>
-                                                    <property name="label" translatable="yes">Open popup menu and switch todo files</property>
                                                   </object>
                                                 </child>
                                               </object>
@@ -1819,6 +1889,14 @@ F3</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">Open stats view</property>
+                                              </object>
+                                            </child>
+                                            <child>
                                               <object class="GtkEntry" id="todo-keybinding-open-to-stats">
                                                 <property name="tooltip_text" translatable="yes">Examples:
 &lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
@@ -1826,12 +1904,6 @@ F3</property>
 F3</property>
                                                 <property name="truncate_multiline">1</property>
                                                 <property name="placeholder_text" translatable="yes">not set</property>
-                                              </object>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="can_focus">0</property>
-                                                <property name="label" translatable="yes">Open stats view</property>
                                               </object>
                                             </child>
                                           </object>
@@ -1854,6 +1926,8 @@ F3</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="can_focus">0</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Open current todo.txt file</property>
                                               </object>
                                             </child>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -424,14 +424,13 @@
                                               <object class="GtkSwitch" id="timer-play-sound-switch"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserButton" id="timer-sound-chooser">
+                                              <object class="GtkButton" id="timer-sound-button">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
-                                                <property name="preview_widget_active">False</property>
-                                                <property name="use_preview_label">False</property>
-                                                <property name="title" translatable="yes"></property>
+                                                <property name="label" translatable="yes"></property>
+                                                <signal name="clicked" handler="_onBtnClicked" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1078,14 +1077,13 @@ F3</property>
                                               <object class="GtkSwitch" id="pomodoro-play-sound-switch-pomo"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-pomo">
+                                              <object class="GtkButton" id="pomodoro-sound-button-pomo">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
-                                                <property name="preview_widget_active">False</property>
-                                                <property name="use_preview_label">False</property>
-                                                <property name="title" translatable="yes"></property>
+                                                <property name="label" translatable="yes"></property>
+                                                <signal name="clicked" handler="_onBtnClicked" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1116,14 +1114,13 @@ F3</property>
                                               <object class="GtkSwitch" id="pomodoro-play-sound-switch-short-break"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-short-break">
+                                              <object class="GtkButton" id="pomodoro-sound-button-short-break">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
-                                                <property name="preview_widget_active">False</property>
-                                                <property name="use_preview_label">False</property>
-                                                <property name="title" translatable="yes"></property>
+                                                <property name="label" translatable="yes"></property>
+                                                <signal name="clicked" handler="_onBtnClicked" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1154,14 +1151,13 @@ F3</property>
                                               <object class="GtkSwitch" id="pomodoro-play-sound-switch-long-break"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-long-break">
+                                              <object class="GtkButton" id="pomodoro-sound-button-long-break">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
-                                                <property name="preview_widget_active">False</property>
-                                                <property name="use_preview_label">False</property>
-                                                <property name="title" translatable="yes"></property>
+                                                <property name="label" translatable="yes"></property>
+                                                <signal name="clicked" handler="_onBtnClicked" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
@@ -1358,14 +1354,13 @@ F3</property>
                                               <object class="GtkSwitch" id="alarms-play-sound-switch"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserButton" id="alarms-sound-chooser">
+                                              <object class="GtkButton" id="alarms-sound-button">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="halign">center</property>
                                                 <property name="valign">center</property>
-                                                <property name="preview_widget_active">False</property>
-                                                <property name="use_preview_label">False</property>
-                                                <property name="title" translatable="yes"></property>
+                                                <property name="label" translatable="yes"></property>
+                                                <signal name="clicked" handler="_onBtnClicked" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -1970,10 +1970,4 @@ F3</property>
       </object>
     </child>
   </object>
-  <object class="GtkFileChooserNative" id="file_chooser">
-    <property name="title" translatable="yes">Choose File</property>
-    <property name="select-multiple">0</property>
-    <property name="action">open</property>
-    <property name="modal">1</property>
-  </object>
 </interface>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkAdjustment" id="todo-width-spin-adjustment">
     <property name="lower">50</property>
     <property name="upper">3000</property>
@@ -11,2880 +10,1901 @@
   <object class="GtkBox" id="settings_widget">
     <property name="width_request">800</property>
     <property name="height_request">500</property>
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can_focus">0</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkStack" id="settings_stack">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="vexpand">True</property>
+        <property name="can_focus">0</property>
+        <property name="vexpand">1</property>
         <property name="transition_type">slide-left-right</property>
-        <property name="interpolate_size">True</property>
+        <property name="interpolate_size">1</property>
         <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <child>
-                  <object class="GtkViewport">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">100</property>
-                        <property name="margin_right">100</property>
-                        <property name="margin_top">20</property>
-                        <property name="margin_bottom">20</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_bottom">12</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Show only 1 panel icon for joined menus</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="unicon-mode-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Position in the panel</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="panel-item-position-combo">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="active">2</property>
-                                            <items>
-                                              <item translatable="yes">Left</item>
-                                              <item translatable="yes">Center</item>
-                                              <item translatable="yes">Right</item>
-                                            </items>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">baseline</property>
-                            <property name="label" translatable="yes">Enabled Sections</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Timer</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="timer-enable-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Stopwatch</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="stopwatch-enable-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Pomodoro</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="pomodoro-enable-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Alarms</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="alarms-enable-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Todo and Time Tracker</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="todo-enable-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">3</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
+          <object class="GtkStackPage">
             <property name="name">page0</property>
             <property name="title" translatable="yes">General</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
+            <property name="child">
+              <object class="GtkBox">
+                <property name="can_focus">0</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkViewport">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">100</property>
-                        <property name="margin_right">100</property>
-                        <property name="margin_top">20</property>
-                        <property name="margin_bottom">20</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_bottom">12</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
+                  <object class="GtkScrolledWindow">
+                    <property name="hexpand">1</property>
+                    <property name="vexpand">1</property>
+                    <property name="child">
+                      <object class="GtkViewport">
+                        <property name="can_focus">0</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="can_focus">0</property>
+                            <property name="margin-start">100</property>
+                            <property name="margin-end">100</property>
+                            <property name="margin_top">20</property>
+                            <property name="margin_bottom">20</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">10</property>
                             <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Show in separate menu</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="timer-separate-menu-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Show seconds</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="timer-show-seconds-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Panel Item Mode</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="timer-panel-mode-combo">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="active">0</property>
-                                            <items>
-                                              <item translatable="yes">Icon only</item>
-                                              <item translatable="yes">Text only</item>
-                                              <item translatable="yes">Icon and Text</item>
-                                              <item translatable="yes">Dynamic</item>
-                                            </items>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <property name="spacing">16</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Notification sound</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="timer-play-sound-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkFileChooserButton" id="timer-sound-chooser">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="halign">center</property>
-                                            <property name="valign">center</property>
-                                            <property name="preview_widget_active">False</property>
-                                            <property name="use_preview_label">False</property>
-                                            <property name="title" translatable="yes"/>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Notification style</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="timer-notif-style-combo">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="active">0</property>
-                                            <items>
-                                              <item translatable="yes">Standard</item>
-                                              <item translatable="yes">Fullscreen</item>
-                                              <item translatable="yes">None</item>
-                                            </items>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">baseline</property>
-                            <property name="label" translatable="yes">Keyboard shortcuts</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open popup menu</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="timer-keybinding-open">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open in fullscreen</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="timer-keybinding-open-fullscreen">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open popup menu and search presets</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="timer-keybinding-open-to-search-presets">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="name">page1</property>
-            <property name="title" translatable="yes">Timer</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <child>
-                  <object class="GtkViewport">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">100</property>
-                        <property name="margin_right">100</property>
-                        <property name="margin_top">20</property>
-                        <property name="margin_bottom">20</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_bottom">12</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Show in separate menu</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="stopwatch-separate-menu-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Format</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="stopwatch-clock-format-combo">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="active">0</property>
-                                            <items>
-                                              <item translatable="yes">hours:min</item>
-                                              <item translatable="yes">hours:min:sec</item>
-                                              <item translatable="yes">hours:min:sec:centisec</item>
-                                            </items>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Panel Item Mode</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="stopwatch-panel-mode-combo">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="active">0</property>
-                                            <items>
-                                              <item translatable="yes">Icon only</item>
-                                              <item translatable="yes">Text only</item>
-                                              <item translatable="yes">Icon and Text</item>
-                                              <item translatable="yes">Dynamic</item>
-                                            </items>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">baseline</property>
-                            <property name="label" translatable="yes">Keyboard shortcuts</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open popup menu</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="stopwatch-keybinding-open">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open in fullscreen</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="stopwatch-keybinding-open-fullscreen">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="name">page2</property>
-            <property name="title" translatable="yes">Stopwatch</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <child>
-                  <object class="GtkViewport">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">100</property>
-                        <property name="margin_right">100</property>
-                        <property name="margin_top">20</property>
-                        <property name="margin_bottom">20</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_bottom">12</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Show in separate menu</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="pomodoro-separate-menu-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Show seconds</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="pomodoro-show-seconds-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Panel Item Mode</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="pomodoro-panel-mode-combo">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="active">0</property>
-                                            <items>
-                                              <item translatable="yes">Icon only</item>
-                                              <item translatable="yes">Text only</item>
-                                              <item translatable="yes">Icon and Text</item>
-                                              <item translatable="yes">Dynamic</item>
-                                            </items>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Notification style</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="pomodoro-notif-style-combo">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="active">0</property>
-                                            <items>
-                                              <item translatable="yes">Standard</item>
-                                              <item translatable="yes">Fullscreen</item>
-                                              <item translatable="yes">None</item>
-                                            </items>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">baseline</property>
-                            <property name="label" translatable="yes">Notification Sounds</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_bottom">12</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <property name="spacing">16</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Repeat notification sound?</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="pomodoro-do-repeat-notif-sound-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <property name="spacing">16</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Pomodoro</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="pomodoro-play-sound-switch-pomo">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-pomo">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="halign">center</property>
-                                            <property name="valign">center</property>
-                                            <property name="preview_widget_active">False</property>
-                                            <property name="use_preview_label">False</property>
-                                            <property name="title" translatable="yes"/>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">3</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <property name="spacing">16</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Short Break</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="pomodoro-play-sound-switch-short-break">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-short-break">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="halign">center</property>
-                                            <property name="valign">center</property>
-                                            <property name="preview_widget_active">False</property>
-                                            <property name="use_preview_label">False</property>
-                                            <property name="title" translatable="yes"/>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">3</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <property name="spacing">16</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Long Break</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="pomodoro-play-sound-switch-long-break">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-long-break">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="halign">center</property>
-                                            <property name="valign">center</property>
-                                            <property name="preview_widget_active">False</property>
-                                            <property name="use_preview_label">False</property>
-                                            <property name="title" translatable="yes"/>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">3</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">baseline</property>
-                            <property name="label" translatable="yes">Keyboard shortcuts</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">3</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open popup menu</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="pomodoro-keybinding-open">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open in fullscreen</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="pomodoro-keybinding-open-fullscreen">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">4</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="name">page3</property>
-            <property name="title" translatable="yes">Pomodoro</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <child>
-                  <object class="GtkViewport">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">100</property>
-                        <property name="margin_right">100</property>
-                        <property name="margin_top">20</property>
-                        <property name="margin_bottom">20</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_bottom">12</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Show in separate menu</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="alarms-separate-menu-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <property name="spacing">16</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Notification sound</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="alarms-play-sound-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkFileChooserButton" id="alarms-sound-chooser">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="halign">center</property>
-                                            <property name="valign">center</property>
-                                            <property name="preview_widget_active">False</property>
-                                            <property name="use_preview_label">False</property>
-                                            <property name="title" translatable="yes"/>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Notification style</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="alarms-notif-style-combo">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="active">0</property>
-                                            <items>
-                                              <item translatable="yes">Standard</item>
-                                              <item translatable="yes">Fullscreen</item>
-                                              <item translatable="yes">None</item>
-                                            </items>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">baseline</property>
-                            <property name="label" translatable="yes">Keyboard shortcuts</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open popup menu</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="alarms-keybinding-open">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="name">page4</property>
-            <property name="title" translatable="yes">Alarms</property>
-            <property name="position">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <child>
-                  <object class="GtkViewport">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">100</property>
-                        <property name="margin_right">100</property>
-                        <property name="margin_top">20</property>
-                        <property name="margin_bottom">20</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_bottom">12</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="activate_on_single_click">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Show in separate menu</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="todo-separate-menu-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Panel Item Mode</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="todo-panel-mode-combo">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="active">0</property>
-                                            <items>
-                                              <item translatable="yes">Icon only</item>
-                                              <item translatable="yes">Text only</item>
-                                              <item translatable="yes">Icon and Text</item>
-                                            </items>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkSpinButton" id="todo-task-width-spin">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="text">0</property>
-                                            <property name="input_purpose">number</property>
-                                            <property name="adjustment">todo-width-spin-adjustment</property>
-                                            <property name="climb_rate">1</property>
-                                            <property name="numeric">True</property>
-                                            <property name="value">200</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Task width (px)</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Resume tracking after abrupt restart?</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSwitch" id="todo-resume-tracking-switch">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="active">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">baseline</property>
-                            <property name="label" translatable="yes">Keyboard shortcuts</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">3</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_bottom">12</property>
-                            <property name="label_xalign">0</property>
-                            <property name="label_yalign">0</property>
-                            <property name="shadow_type">in</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="activate_on_single_click">False</property>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open popup menu</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="todo-keybinding-open">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open popup menu and add task</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="todo-keybinding-open-to-add">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkEntry" id="todo-keybinding-open-to-search">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open popup menu and search tasks</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="margin_bottom">12</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
                                     <child>
                                       <object class="GtkListBoxRow">
                                         <property name="width_request">100</property>
                                         <property name="height_request">40</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="activatable">False</property>
-                                        <property name="selectable">False</property>
-                                        <child>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
                                           <object class="GtkBox">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="margin_left">10</property>
-                                            <property name="margin_right">10</property>
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
                                             <property name="margin_top">10</property>
                                             <property name="margin_bottom">10</property>
                                             <child>
-                                              <object class="GtkEntry" id="todo-keybinding-open-to-switch-files">
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Show only 1 panel icon for joined menus</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="unicon-mode-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Position in the panel</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="panel-item-position-combo">
+                                                <property name="can_focus">0</property>
+                                                <property name="active">2</property>
+                                                <items>
+                                                  <item translatable="yes">Left</item>
+                                                  <item translatable="yes">Center</item>
+                                                  <item translatable="yes">Right</item>
+                                                </items>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="can_focus">0</property>
+                                <property name="halign">start</property>
+                                <property name="valign">baseline</property>
+                                <property name="label" translatable="yes">Enabled Sections</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"></attribute>
+                                </attributes>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="can_focus">0</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Timer</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="timer-enable-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Stopwatch</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="stopwatch-enable-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Pomodoro</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="pomodoro-enable-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Alarms</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="alarms-enable-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Todo and Time Tracker</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="todo-enable-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStackPage">
+            <property name="name">page1</property>
+            <property name="title" translatable="yes">Timer</property>
+            <property name="position">1</property>
+            <property name="child">
+              <object class="GtkBox">
+                <property name="can_focus">0</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="hexpand">1</property>
+                    <property name="vexpand">1</property>
+                    <property name="child">
+                      <object class="GtkViewport">
+                        <property name="can_focus">0</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="can_focus">0</property>
+                            <property name="margin-start">100</property>
+                            <property name="margin-end">100</property>
+                            <property name="margin_top">20</property>
+                            <property name="margin_bottom">20</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">10</property>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="margin_bottom">12</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Show in separate menu</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="timer-separate-menu-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Show seconds</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="timer-show-seconds-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Panel Item Mode</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="timer-panel-mode-combo">
+                                                <property name="can_focus">0</property>
+                                                <property name="active">0</property>
+                                                <items>
+                                                  <item translatable="yes">Icon only</item>
+                                                  <item translatable="yes">Text only</item>
+                                                  <item translatable="yes">Icon and Text</item>
+                                                  <item translatable="yes">Dynamic</item>
+                                                </items>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <property name="spacing">16</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Notification sound</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="timer-play-sound-switch"/>
+                                            </child>
+                                            <child>
+                                              <object class="GtkFileChooserButton" id="timer-sound-chooser">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="preview_widget_active">False</property>
+                                                <property name="use_preview_label">False</property>
+                                                <property name="title" translatable="yes"></property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Notification style</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="timer-notif-style-combo">
+                                                <property name="can_focus">0</property>
+                                                <property name="active">0</property>
+                                                <items>
+                                                  <item translatable="yes">Standard</item>
+                                                  <item translatable="yes">Fullscreen</item>
+                                                  <item translatable="yes">None</item>
+                                                </items>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="can_focus">0</property>
+                                <property name="halign">start</property>
+                                <property name="valign">baseline</property>
+                                <property name="label" translatable="yes">Keyboard shortcuts</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"></attribute>
+                                </attributes>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open popup menu</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="timer-keybinding-open">
                                                 <property name="tooltip_text" translatable="yes">Examples:
 &lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
 &lt;shift&gt;super
 F3</property>
-                                                <property name="truncate_multiline">True</property>
+                                                <property name="truncate_multiline">1</property>
                                                 <property name="placeholder_text" translatable="yes">not set</property>
                                               </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="pack_type">end</property>
-                                                <property name="position">0</property>
-                                              </packing>
                                             </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="label" translatable="yes">Open popup menu and switch todo files</property>
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open in fullscreen</property>
                                               </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="timer-keybinding-open-fullscreen">
+                                                <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
                                             </child>
                                           </object>
-                                        </child>
+                                        </property>
                                       </object>
                                     </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
                                     <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkEntry" id="todo-keybinding-open-to-stats">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open popup menu and search presets</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="timer-keybinding-open-to-search-presets">
+                                                <property name="tooltip_text" translatable="yes">Examples:
 &lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
 &lt;shift&gt;super
 F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
+                                            </child>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open stats view</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        </property>
                                       </object>
                                     </child>
                                   </object>
-                                </child>
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="width_request">100</property>
-                                    <property name="height_request">40</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="activatable">False</property>
-                                    <property name="selectable">False</property>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_left">10</property>
-                                        <property name="margin_right">10</property>
-                                        <property name="margin_top">10</property>
-                                        <property name="margin_bottom">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Open current todo.txt file</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="todo-keybinding-open-todotxt-file">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Examples:
-&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
-&lt;shift&gt;super
-F3</property>
-                                            <property name="truncate_multiline">True</property>
-                                            <property name="placeholder_text" translatable="yes">not set</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
                                 </child>
                               </object>
                             </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">4</property>
-                          </packing>
-                        </child>
+                        </property>
                       </object>
-                    </child>
+                    </property>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
+            </property>
           </object>
-          <packing>
+        </child>
+        <child>
+          <object class="GtkStackPage">
+            <property name="name">page2</property>
+            <property name="title" translatable="yes">Stopwatch</property>
+            <property name="position">2</property>
+            <property name="child">
+              <object class="GtkBox">
+                <property name="can_focus">0</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="hexpand">1</property>
+                    <property name="vexpand">1</property>
+                    <property name="child">
+                      <object class="GtkViewport">
+                        <property name="can_focus">0</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="can_focus">0</property>
+                            <property name="margin-start">100</property>
+                            <property name="margin-end">100</property>
+                            <property name="margin_top">20</property>
+                            <property name="margin_bottom">20</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">10</property>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="margin_bottom">12</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Show in separate menu</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="stopwatch-separate-menu-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Format</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="stopwatch-clock-format-combo">
+                                                <property name="can_focus">0</property>
+                                                <property name="active">0</property>
+                                                <items>
+                                                  <item translatable="yes">hours:min</item>
+                                                  <item translatable="yes">hours:min:sec</item>
+                                                  <item translatable="yes">hours:min:sec:centisec</item>
+                                                </items>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Panel Item Mode</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="stopwatch-panel-mode-combo">
+                                                <property name="can_focus">0</property>
+                                                <property name="active">0</property>
+                                                <items>
+                                                  <item translatable="yes">Icon only</item>
+                                                  <item translatable="yes">Text only</item>
+                                                  <item translatable="yes">Icon and Text</item>
+                                                  <item translatable="yes">Dynamic</item>
+                                                </items>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="can_focus">0</property>
+                                <property name="halign">start</property>
+                                <property name="valign">baseline</property>
+                                <property name="label" translatable="yes">Keyboard shortcuts</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"></attribute>
+                                </attributes>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open popup menu</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="stopwatch-keybinding-open">
+                                                <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open in fullscreen</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="stopwatch-keybinding-open-fullscreen">
+                                                <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStackPage">
+            <property name="name">page3</property>
+            <property name="title" translatable="yes">Pomodoro</property>
+            <property name="position">3</property>
+            <property name="child">
+              <object class="GtkBox">
+                <property name="can_focus">0</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="hexpand">1</property>
+                    <property name="vexpand">1</property>
+                    <property name="child">
+                      <object class="GtkViewport">
+                        <property name="can_focus">0</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="can_focus">0</property>
+                            <property name="margin-start">100</property>
+                            <property name="margin-end">100</property>
+                            <property name="margin_top">20</property>
+                            <property name="margin_bottom">20</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">10</property>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="margin_bottom">12</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Show in separate menu</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="pomodoro-separate-menu-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Show seconds</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="pomodoro-show-seconds-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Panel Item Mode</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="pomodoro-panel-mode-combo">
+                                                <property name="can_focus">0</property>
+                                                <property name="active">0</property>
+                                                <items>
+                                                  <item translatable="yes">Icon only</item>
+                                                  <item translatable="yes">Text only</item>
+                                                  <item translatable="yes">Icon and Text</item>
+                                                  <item translatable="yes">Dynamic</item>
+                                                </items>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Notification style</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="pomodoro-notif-style-combo">
+                                                <property name="can_focus">0</property>
+                                                <property name="active">0</property>
+                                                <items>
+                                                  <item translatable="yes">Standard</item>
+                                                  <item translatable="yes">Fullscreen</item>
+                                                  <item translatable="yes">None</item>
+                                                </items>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="can_focus">0</property>
+                                <property name="halign">start</property>
+                                <property name="valign">baseline</property>
+                                <property name="label" translatable="yes">Notification Sounds</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"></attribute>
+                                </attributes>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="margin_bottom">12</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <property name="spacing">16</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Repeat notification sound?</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="pomodoro-do-repeat-notif-sound-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <property name="spacing">16</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Pomodoro</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="pomodoro-play-sound-switch-pomo"/>
+                                            </child>
+                                            <child>
+                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-pomo">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="preview_widget_active">False</property>
+                                                <property name="use_preview_label">False</property>
+                                                <property name="title" translatable="yes"></property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <property name="spacing">16</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Short Break</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="pomodoro-play-sound-switch-short-break"/>
+                                            </child>
+                                            <child>
+                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-short-break">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="preview_widget_active">False</property>
+                                                <property name="use_preview_label">False</property>
+                                                <property name="title" translatable="yes"></property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <property name="spacing">16</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Long Break</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="pomodoro-play-sound-switch-long-break"/>
+                                            </child>
+                                            <child>
+                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-long-break">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="preview_widget_active">False</property>
+                                                <property name="use_preview_label">False</property>
+                                                <property name="title" translatable="yes"></property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="can_focus">0</property>
+                                <property name="halign">start</property>
+                                <property name="valign">baseline</property>
+                                <property name="label" translatable="yes">Keyboard shortcuts</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"></attribute>
+                                </attributes>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open popup menu</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="pomodoro-keybinding-open">
+                                                <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open in fullscreen</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="pomodoro-keybinding-open-fullscreen">
+                                                <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStackPage">
+            <property name="name">page4</property>
+            <property name="title" translatable="yes">Alarms</property>
+            <property name="position">4</property>
+            <property name="child">
+              <object class="GtkBox">
+                <property name="can_focus">0</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="hexpand">1</property>
+                    <property name="vexpand">1</property>
+                    <property name="child">
+                      <object class="GtkViewport">
+                        <property name="can_focus">0</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="can_focus">0</property>
+                            <property name="margin-start">100</property>
+                            <property name="margin-end">100</property>
+                            <property name="margin_top">20</property>
+                            <property name="margin_bottom">20</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">10</property>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="margin_bottom">12</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Show in separate menu</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="alarms-separate-menu-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <property name="spacing">16</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Notification sound</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="alarms-play-sound-switch"/>
+                                            </child>
+                                            <child>
+                                              <object class="GtkFileChooserButton" id="alarms-sound-chooser">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="preview_widget_active">False</property>
+                                                <property name="use_preview_label">False</property>
+                                                <property name="title" translatable="yes"></property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Notification style</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="alarms-notif-style-combo">
+                                                <property name="can_focus">0</property>
+                                                <property name="active">0</property>
+                                                <items>
+                                                  <item translatable="yes">Standard</item>
+                                                  <item translatable="yes">Fullscreen</item>
+                                                  <item translatable="yes">None</item>
+                                                </items>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="can_focus">0</property>
+                                <property name="halign">start</property>
+                                <property name="valign">baseline</property>
+                                <property name="label" translatable="yes">Keyboard shortcuts</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"></attribute>
+                                </attributes>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open popup menu</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="alarms-keybinding-open">
+                                                <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStackPage">
             <property name="name">page5</property>
             <property name="title" translatable="yes">Todo / Time Tracker</property>
             <property name="position">5</property>
-          </packing>
+            <property name="child">
+              <object class="GtkBox">
+                <property name="can_focus">0</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="hexpand">1</property>
+                    <property name="vexpand">1</property>
+                    <property name="child">
+                      <object class="GtkViewport">
+                        <property name="can_focus">0</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="can_focus">0</property>
+                            <property name="margin-start">100</property>
+                            <property name="margin-end">100</property>
+                            <property name="margin_top">20</property>
+                            <property name="margin_bottom">20</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">10</property>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="margin_bottom">12</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <property name="activate_on_single_click">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Show in separate menu</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="todo-separate-menu-switch"/>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Panel Item Mode</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="todo-panel-mode-combo">
+                                                <property name="can_focus">0</property>
+                                                <property name="active">0</property>
+                                                <items>
+                                                  <item translatable="yes">Icon only</item>
+                                                  <item translatable="yes">Text only</item>
+                                                  <item translatable="yes">Icon and Text</item>
+                                                </items>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkSpinButton" id="todo-task-width-spin">
+                                                <property name="text">0</property>
+                                                <property name="input_purpose">number</property>
+                                                <property name="adjustment">todo-width-spin-adjustment</property>
+                                                <property name="climb_rate">1</property>
+                                                <property name="numeric">1</property>
+                                                <property name="value">200</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Task width (px)</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Resume tracking after abrupt restart?</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSwitch" id="todo-resume-tracking-switch">
+                                                <property name="active">1</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="can_focus">0</property>
+                                <property name="halign">start</property>
+                                <property name="valign">baseline</property>
+                                <property name="label" translatable="yes">Keyboard shortcuts</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"></attribute>
+                                </attributes>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="valign">center</property>
+                                <property name="can_focus">0</property>
+                                <property name="margin_bottom">12</property>
+                                <property name="label_yalign">0</property>
+                                <property name="shadow_type">in</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <property name="can_focus">0</property>
+                                    <property name="activate_on_single_click">0</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open popup menu</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="todo-keybinding-open">
+                                                <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open popup menu and add task</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="todo-keybinding-open-to-add">
+                                                <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkEntry" id="todo-keybinding-open-to-search">
+                                                <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open popup menu and search tasks</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkListBoxRow">
+                                            <property name="width_request">100</property>
+                                            <property name="height_request">40</property>
+                                            <property name="activatable">0</property>
+                                            <property name="selectable">0</property>
+                                            <property name="child">
+                                              <object class="GtkBox">
+                                                <property name="can_focus">0</property>
+                                                <property name="margin-start">10</property>
+                                                <property name="margin-end">10</property>
+                                                <property name="margin_top">10</property>
+                                                <property name="margin_bottom">10</property>
+                                                <child>
+                                                  <object class="GtkEntry" id="todo-keybinding-open-to-switch-files">
+                                                    <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                    <property name="truncate_multiline">1</property>
+                                                    <property name="placeholder_text" translatable="yes">not set</property>
+                                                  </object>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkLabel">
+                                                    <property name="can_focus">0</property>
+                                                    <property name="label" translatable="yes">Open popup menu and switch todo files</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </property>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkEntry" id="todo-keybinding-open-to-stats">
+                                                <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open stats view</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="width_request">100</property>
+                                        <property name="height_request">40</property>
+                                        <property name="activatable">0</property>
+                                        <property name="selectable">0</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="can_focus">0</property>
+                                            <property name="margin-start">10</property>
+                                            <property name="margin-end">10</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">10</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="can_focus">0</property>
+                                                <property name="label" translatable="yes">Open current todo.txt file</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="todo-keybinding-open-todotxt-file">
+                                                <property name="tooltip_text" translatable="yes">Examples:
+&lt;super&gt;&lt;ctrl&gt;&lt;alt&gt;&lt;shift&gt;t
+&lt;shift&gt;super
+F3</property>
+                                                <property name="truncate_multiline">1</property>
+                                                <property name="placeholder_text" translatable="yes">not set</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                                <child type="label_item">
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -1580,7 +1580,6 @@ F3</property>
                                             <child>
                                               <object class="GtkSpinButton" id="todo-task-width-spin">
                                                 <property name="text">0</property>
-                                                <property name="input_purpose">number</property>
                                                 <property name="adjustment">todo-width-spin-adjustment</property>
                                                 <property name="climb_rate">1</property>
                                                 <property name="numeric">1</property>

--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -424,13 +424,11 @@
                                               <object class="GtkSwitch" id="timer-play-sound-switch"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserButton" id="timer-sound-chooser">
+                                              <object class="GtkFileChooserNative" id="timer-sound-chooser">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="preview_widget_active">False</property>
-                                                <property name="use_preview_label">False</property>
+                                                <property name="select-multiple">0</property>
+                                                <property name="action">open</property>
+                                                <property name="modal">1</property>
                                                 <property name="title" translatable="yes"></property>
                                               </object>
                                             </child>
@@ -1078,13 +1076,11 @@ F3</property>
                                               <object class="GtkSwitch" id="pomodoro-play-sound-switch-pomo"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-pomo">
+                                              <object class="GtkFileChooserNative" id="pomodoro-sound-chooser-pomo">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="preview_widget_active">False</property>
-                                                <property name="use_preview_label">False</property>
+                                                <property name="select-multiple">0</property>
+                                                <property name="action">open</property>
+                                                <property name="modal">1</property>
                                                 <property name="title" translatable="yes"></property>
                                               </object>
                                             </child>
@@ -1116,13 +1112,11 @@ F3</property>
                                               <object class="GtkSwitch" id="pomodoro-play-sound-switch-short-break"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-short-break">
+                                              <object class="GtkFileChooserNative" id="pomodoro-sound-chooser-short-break">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="preview_widget_active">False</property>
-                                                <property name="use_preview_label">False</property>
+                                                <property name="select-multiple">0</property>
+                                                <property name="action">open</property>
+                                                <property name="modal">1</property>
                                                 <property name="title" translatable="yes"></property>
                                               </object>
                                             </child>
@@ -1154,13 +1148,11 @@ F3</property>
                                               <object class="GtkSwitch" id="pomodoro-play-sound-switch-long-break"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserButton" id="pomodoro-sound-chooser-long-break">
+                                              <object class="GtkFileChooserNative" id="pomodoro-sound-chooser-long-break">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="preview_widget_active">False</property>
-                                                <property name="use_preview_label">False</property>
+                                                <property name="select-multiple">0</property>
+                                                <property name="action">open</property>
+                                                <property name="modal">1</property>
                                                 <property name="title" translatable="yes"></property>
                                               </object>
                                             </child>
@@ -1358,13 +1350,11 @@ F3</property>
                                               <object class="GtkSwitch" id="alarms-play-sound-switch"/>
                                             </child>
                                             <child>
-                                              <object class="GtkFileChooserButton" id="alarms-sound-chooser">
+                                              <object class="GtkFileChooserNative" id="alarms-sound-chooser">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="halign">center</property>
-                                                <property name="valign">center</property>
-                                                <property name="preview_widget_active">False</property>
-                                                <property name="use_preview_label">False</property>
+                                                <property name="select-multiple">0</property>
+                                                <property name="action">open</property>
+                                                <property name="modal">1</property>
                                                 <property name="title" translatable="yes"></property>
                                               </object>
                                             </child>

--- a/prefs.js
+++ b/prefs.js
@@ -23,7 +23,6 @@ class Settings {
         this.builder.add_from_file(ME.path + '/data/prefs.ui');
 
         this.widget = this.builder.get_object('settings_widget');
-        this.file_chooser = this.builder.get_object('file_chooser');
         this.switcher = new Gtk.StackSwitcher({ visible: true, stack: this.builder.get_object('settings_stack'), halign: Gtk.Align.CENTER, });
 
         this._bind_settings();
@@ -115,10 +114,8 @@ class Settings {
         }
 
         widget = this.builder.get_object('timer-sound-button');
-        widget.set_uri(this.settings.get_string('timer-sound-file-path'));
-        widget.connect('selection-changed', (widget) => {
-            this.settings.set_string('timer-sound-file-path', widget.get_uri());
-        });
+        widget.connect('clicked', (widget) => this._open_file_chooser(widget, 'timer-sound-file-path'));
+        
 
         widget = this.builder.get_object('timer-notif-style-combo');
         widget.set_active(this.settings.get_enum('timer-notif-style'));
@@ -294,22 +291,13 @@ class Settings {
         }
 
         widget = this.builder.get_object('pomodoro-sound-button-pomo');
-        widget.set_uri(this.settings.get_string('pomodoro-sound-file-path-pomo'));
-        widget.connect('selection-changed', (widget) => {
-            this.settings.set_string('pomodoro-sound-file-path-pomo', widget.get_uri());
-        });
+        widget.connect('clicked', (widget) => this._open_file_chooser(widget, 'pomodoro-sound-file-path-pomo'));
 
         widget = this.builder.get_object('pomodoro-sound-button-short-break');
-        widget.set_uri(this.settings.get_string('pomodoro-sound-file-path-short-break'));
-        widget.connect('selection-changed', (widget) => {
-            this.settings.set_string('pomodoro-sound-file-path-short-break', widget.get_uri());
-        });
+        widget.connect('clicked', (widget) => this._open_file_chooser(widget, 'pomodoro-sound-file-path-short-break'));
 
         widget = this.builder.get_object('pomodoro-sound-button-long-break');
-        widget.set_uri(this.settings.get_string('pomodoro-sound-file-path-long-break'));
-        widget.connect('selection-changed', (widget) => {
-            this.settings.set_string('pomodoro-sound-file-path-long-break', widget.get_uri());
-        });
+        widget.connect('clicked', (widget) => this._open_file_chooser(widget, 'pomodoro-sound-file-path-long-break'));
 
         this.settings.bind(
             'pomodoro-play-sound-pomo',
@@ -381,10 +369,7 @@ class Settings {
         }
 
         widget = this.builder.get_object('alarms-sound-button');
-        widget.set_uri(this.settings.get_string('alarms-sound-file-path'));
-        widget.connect('selection-changed', (widget) => {
-            this.settings.set_string('alarms-sound-file-path', widget.get_uri());
-        });
+        widget.connect('clicked', (widget) => this._open_file_chooser(widget, 'alarms-sound-file-path'));
 
         widget = this.builder.get_object('alarms-notif-style-combo');
         widget.set_active(this.settings.get_enum('alarms-notif-style'));
@@ -567,6 +552,26 @@ class Settings {
             window.set_titlebar(headerBar);
             return false;
         });
+    }
+
+    _open_file_chooser(widget, settingsKey) {
+        let parent = widget.get_root();
+        let file_chooser = new Gtk.FileChooserNative({
+            title: "Choose file",
+            action: Gtk.FileChooserAction.OPEN
+        });
+
+        file_chooser.set_transient_for(parent);
+        file_chooser.set_select_multiple(false);
+        file_chooser.set_modal(true);
+        file_chooser.set_file(Gio.File.new_for_uri(this.settings.get_string(settingsKey)));
+        file_chooser.connect('response', (widget, response) => {
+            if (response !== Gtk.ResponseType.ACCEPT) {
+                return;
+            }
+            this.settings.set_string(settingsKey, widget.get_file().get_uri());
+        });
+        file_chooser.show();
     }
 }
 

--- a/prefs.js
+++ b/prefs.js
@@ -32,7 +32,7 @@ class Settings {
         {
             let GioSSS = Gio.SettingsSchemaSource;
             let schema = GioSSS.new_from_directory(
-                ME.path + '/data/schemas', GioSSS.get_default(), false);
+                ME.dir.get_path() + '/data/schemas', GioSSS.get_default(), false);
             schema = schema.lookup('org.gnome.shell.extensions.timepp', false);
 
             this.settings = new Gio.Settings({ settings_schema: schema });
@@ -130,7 +130,7 @@ class Settings {
         });
 
         if (! this.settings.get_string('timer-sound-file-path')) {
-            this.settings.set_string('timer-sound-file-path', GLib.filename_to_uri(ME.path + '/data/sounds/beeps.ogg', null));
+            this.settings.set_string('timer-sound-file-path', GLib.filename_to_uri(ME.dir.get_path() + '/data/sounds/beeps.ogg', null));
         }
 
         widget = this.builder.get_object('timer-sound-button');
@@ -304,15 +304,15 @@ class Settings {
             Gio.SettingsBindFlags.DEFAULT);
 
         if (! this.settings.get_string('pomodoro-sound-file-path-pomo')) {
-            this.settings.set_string('pomodoro-sound-file-path-pomo', GLib.filename_to_uri(ME.path + '/data/sounds/beeps.ogg', null));
+            this.settings.set_string('pomodoro-sound-file-path-pomo', GLib.filename_to_uri(ME.dir.get_path() + '/data/sounds/beeps.ogg', null));
         }
 
         if (! this.settings.get_string('pomodoro-sound-file-path-short-break')) {
-            this.settings.set_string('pomodoro-sound-file-path-short-break', GLib.filename_to_uri(ME.path + '/data/sounds/beeps.ogg', null));
+            this.settings.set_string('pomodoro-sound-file-path-short-break', GLib.filename_to_uri(ME.dir.get_path() + '/data/sounds/beeps.ogg', null));
         }
 
         if (!  this.settings.get_string('pomodoro-sound-file-path-long-break')) {
-            this.settings.set_string('pomodoro-sound-file-path-long-break', GLib.filename_to_uri(ME.path + '/data/sounds/beeps.ogg', null));
+            this.settings.set_string('pomodoro-sound-file-path-long-break', GLib.filename_to_uri(ME.dir.get_path() + '/data/sounds/beeps.ogg', null));
         }
 
         widget = this.builder.get_object('pomodoro-sound-button-pomo');
@@ -408,7 +408,7 @@ class Settings {
             Gio.SettingsBindFlags.DEFAULT);
 
         if (! this.settings.get_string('alarms-sound-file-path')) {
-            this.settings.set_string('alarms-sound-file-path', GLib.filename_to_uri(ME.path + '/data/sounds/beeps.ogg', null));
+            this.settings.set_string('alarms-sound-file-path', GLib.filename_to_uri(ME.dir.get_path() + '/data/sounds/beeps.ogg', null));
         }
 
         widget = this.builder.get_object('alarms-sound-button');

--- a/prefs.js
+++ b/prefs.js
@@ -47,6 +47,7 @@ class Settings {
         this.switcher = new Gtk.StackSwitcher({ visible: true, stack: this.builder.get_object('settings_stack'), halign: Gtk.Align.CENTER, });
 
         this._bind_settings();
+        this._set_headerbar();
     }
 
     // Bind the gtk window to the schema settings
@@ -592,19 +593,21 @@ class Settings {
             }
         });
     }
+
+    _set_headerbar() {
+        this.widget.connect('realize', () => {
+            let window = this.widget.get_root();
+            let headerBar = new Gtk.HeaderBar();
+            headerBar.set_title_widget(this.switcher);
+            window.set_titlebar(headerBar);
+            return false;
+        });
+    }
 }
 
 function buildPrefsWidget () {
     let settings = new Settings();
-    let widget = settings.widget;
-
-    Mainloop.timeout_add(0, () => {
-        let header_bar = widget.get_toplevel().get_titlebar();
-        header_bar.custom_title = settings.switcher;
-        return false;
-    });
-
-    return widget;
+    return settings.widget;
 }
 
 function init () {

--- a/prefs.js
+++ b/prefs.js
@@ -131,9 +131,9 @@ class Settings {
         widget = this.builder.get_object('timer-keybinding-open');
         widget.set_text(this.settings.get_strv('timer-keybinding-open')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('timer-keybinding-open', [shortcut]);
@@ -150,9 +150,9 @@ class Settings {
         widget = this.builder.get_object('timer-keybinding-open-fullscreen');
         widget.set_text(this.settings.get_strv('timer-keybinding-open-fullscreen')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-                if (Gtk.accelerator_valid(key, mods)) {
+                if (ok) {
                     entry["secondary-icon-name"] = null;
                     let shortcut = Gtk.accelerator_name(key, mods);
                     this.settings.set_strv('timer-keybinding-open-fullscreen', [shortcut]);
@@ -169,9 +169,9 @@ class Settings {
         widget = this.builder.get_object('timer-keybinding-open-to-search-presets');
         widget.set_text(this.settings.get_strv('timer-keybinding-open-to-search-presets')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('timer-keybinding-open-to-search-presets', [shortcut]);
@@ -209,9 +209,9 @@ class Settings {
         widget = this.builder.get_object('stopwatch-keybinding-open');
         widget.set_text(this.settings.get_strv('stopwatch-keybinding-open')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('stopwatch-keybinding-open', [shortcut]);
@@ -228,9 +228,9 @@ class Settings {
         widget = this.builder.get_object('stopwatch-keybinding-open-fullscreen');
         widget.set_text(this.settings.get_strv('stopwatch-keybinding-open-fullscreen')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('stopwatch-keybinding-open-fullscreen', [shortcut]);
@@ -319,9 +319,9 @@ class Settings {
         widget = this.builder.get_object('pomodoro-keybinding-open');
         widget.set_text(this.settings.get_strv('pomodoro-keybinding-open')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-                if (Gtk.accelerator_valid(key, mods)) {
+                if (ok) {
                     entry["secondary-icon-name"] = null;
                     let shortcut = Gtk.accelerator_name(key, mods);
                     this.settings.set_strv('pomodoro-keybinding-open', [shortcut]);
@@ -338,9 +338,9 @@ class Settings {
         widget = this.builder.get_object('pomodoro-keybinding-open-fullscreen');
         widget.set_text(this.settings.get_strv('pomodoro-keybinding-open-fullscreen')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('pomodoro-keybinding-open-fullscreen', [shortcut]);
@@ -385,9 +385,9 @@ class Settings {
         widget = this.builder.get_object('alarms-keybinding-open');
         widget.set_text(this.settings.get_strv('alarms-keybinding-open')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('alarms-keybinding-open', [shortcut]);
@@ -431,9 +431,9 @@ class Settings {
         widget = this.builder.get_object('todo-keybinding-open');
         widget.set_text(this.settings.get_strv('todo-keybinding-open')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('todo-keybinding-open', [shortcut]);
@@ -450,9 +450,9 @@ class Settings {
         widget = this.builder.get_object('todo-keybinding-open-to-add');
         widget.set_text(this.settings.get_strv('todo-keybinding-open-to-add')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('todo-keybinding-open-to-add', [shortcut]);
@@ -469,9 +469,9 @@ class Settings {
         widget = this.builder.get_object('todo-keybinding-open-to-search');
         widget.set_text(this.settings.get_strv('todo-keybinding-open-to-search')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('todo-keybinding-open-to-search', [shortcut]);
@@ -488,9 +488,9 @@ class Settings {
         widget = this.builder.get_object('todo-keybinding-open-to-stats');
         widget.set_text(this.settings.get_strv('todo-keybinding-open-to-stats')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('todo-keybinding-open-to-stats', [shortcut]);
@@ -507,9 +507,9 @@ class Settings {
         widget = this.builder.get_object('todo-keybinding-open-to-switch-files');
         widget.set_text(this.settings.get_strv('todo-keybinding-open-to-switch-files')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('todo-keybinding-open-to-switch-files', [shortcut]);
@@ -526,9 +526,9 @@ class Settings {
         widget = this.builder.get_object('todo-keybinding-open-todotxt-file');
         widget.set_text(this.settings.get_strv('todo-keybinding-open-todotxt-file')[0]);
         widget.connect('changed', (entry) => {
-            let [key, mods] = Gtk.accelerator_parse(entry.get_text());
+            let [ok, key, mods] = Gtk.accelerator_parse(entry.get_text());
 
-            if (Gtk.accelerator_valid(key, mods)) {
+            if (ok) {
                 entry["secondary-icon-name"] = null;
                 let shortcut = Gtk.accelerator_name(key, mods);
                 this.settings.set_strv('todo-keybinding-open-todotxt-file', [shortcut]);

--- a/prefs.js
+++ b/prefs.js
@@ -1,7 +1,6 @@
 const Gio            = imports.gi.Gio;
 const Gtk            = imports.gi.Gtk;
 const GLib           = imports.gi.GLib;
-const Mainloop       = imports.mainloop;
 const ExtensionUtils = imports.misc.extensionUtils;
 
 const ME = ExtensionUtils.getCurrentExtension();

--- a/prefs.js
+++ b/prefs.js
@@ -112,7 +112,7 @@ class Settings {
             this.settings.set_string('timer-sound-file-path', GLib.filename_to_uri(ME.path + '/data/sounds/beeps.ogg', null));
         }
 
-        widget = this.builder.get_object('timer-sound-chooser');
+        widget = this.builder.get_object('timer-sound-button');
         widget.set_uri(this.settings.get_string('timer-sound-file-path'));
         widget.connect('selection-changed', (widget) => {
             this.settings.set_string('timer-sound-file-path', widget.get_uri());
@@ -291,19 +291,19 @@ class Settings {
             this.settings.set_string('pomodoro-sound-file-path-long-break', GLib.filename_to_uri(ME.path + '/data/sounds/beeps.ogg', null));
         }
 
-        widget = this.builder.get_object('pomodoro-sound-chooser-pomo');
+        widget = this.builder.get_object('pomodoro-sound-button-pomo');
         widget.set_uri(this.settings.get_string('pomodoro-sound-file-path-pomo'));
         widget.connect('selection-changed', (widget) => {
             this.settings.set_string('pomodoro-sound-file-path-pomo', widget.get_uri());
         });
 
-        widget = this.builder.get_object('pomodoro-sound-chooser-short-break');
+        widget = this.builder.get_object('pomodoro-sound-button-short-break');
         widget.set_uri(this.settings.get_string('pomodoro-sound-file-path-short-break'));
         widget.connect('selection-changed', (widget) => {
             this.settings.set_string('pomodoro-sound-file-path-short-break', widget.get_uri());
         });
 
-        widget = this.builder.get_object('pomodoro-sound-chooser-long-break');
+        widget = this.builder.get_object('pomodoro-sound-button-long-break');
         widget.set_uri(this.settings.get_string('pomodoro-sound-file-path-long-break'));
         widget.connect('selection-changed', (widget) => {
             this.settings.set_string('pomodoro-sound-file-path-long-break', widget.get_uri());
@@ -378,7 +378,7 @@ class Settings {
             this.settings.set_string('alarms-sound-file-path', GLib.filename_to_uri(ME.path + '/data/sounds/beeps.ogg', null));
         }
 
-        widget = this.builder.get_object('alarms-sound-chooser');
+        widget = this.builder.get_object('alarms-sound-button');
         widget.set_uri(this.settings.get_string('alarms-sound-file-path'));
         widget.connect('selection-changed', (widget) => {
             this.settings.set_string('alarms-sound-file-path', widget.get_uri());

--- a/prefs.js
+++ b/prefs.js
@@ -1,11 +1,31 @@
 const Gio            = imports.gi.Gio;
 const Gtk            = imports.gi.Gtk;
 const GLib           = imports.gi.GLib;
+const GObject        = imports.gi.GObject;
 const Mainloop       = imports.mainloop;
 const ExtensionUtils = imports.misc.extensionUtils;
 
 const ME = ExtensionUtils.getCurrentExtension();
 const _  = imports.gettext.domain('timepp').gettext;
+
+const TimePpBuilderScope = GObject.registerClass({
+    Implements: [Gtk.BuilderScope],
+}, class TimePpBuilderScope extends GObject.Object {
+
+    vfunc_create_closure(builder, handlerName, flags, connectObject) {
+        if (flags & Gtk.BuilderClosureFlags.SWAPPED)
+            throw new Error('Unsupported template signal flag "swapped"');
+        
+        if (typeof this[handlerName] === 'undefined')
+            throw new Error(`${handlerName} is undefined`);
+        
+        return this[handlerName].bind(connectObject || this);
+    }
+    
+    on_btn_click(connectObject) {
+        connectObject.set_label("Clicked");
+    }
+});
 
 class Settings {
     constructor () {
@@ -19,8 +39,9 @@ class Settings {
         }
 
         this.builder = new Gtk.Builder();
+        this.builder.set_scope(new TimePpBuilderScope());
         this.builder.set_translation_domain('timepp');
-        this.builder.add_from_file(ME.path + '/data/prefs.ui');
+        this.builder.add_from_file(ME.dir.get_path() + '/data/prefs.ui');
 
         this.widget = this.builder.get_object('settings_widget');
         this.switcher = new Gtk.StackSwitcher({ visible: true, stack: this.builder.get_object('settings_stack'), halign: Gtk.Align.CENTER, });
@@ -113,10 +134,13 @@ class Settings {
         }
 
         widget = this.builder.get_object('timer-sound-button');
-        widget.set_uri(this.settings.get_string('timer-sound-file-path'));
-        widget.connect('selection-changed', (widget) => {
-            this.settings.set_string('timer-sound-file-path', widget.get_uri());
-        });
+        // widget.set_file(Gio.File.new_from_uri(this.settings.get_string('timer-sound-file-path')));
+        // widget.prototype._onFileChooserResponse = (widget, response) => {
+        //     if (response !== Gtk.ResponseType.ACCEPT) {
+        //         return;
+        //     }
+        //     this.settings.set_string('timer-sound-file-path', widget.get_file().get_uri());
+        // };
 
         widget = this.builder.get_object('timer-notif-style-combo');
         widget.set_active(this.settings.get_enum('timer-notif-style'));
@@ -292,22 +316,31 @@ class Settings {
         }
 
         widget = this.builder.get_object('pomodoro-sound-button-pomo');
-        widget.set_uri(this.settings.get_string('pomodoro-sound-file-path-pomo'));
-        widget.connect('selection-changed', (widget) => {
-            this.settings.set_string('pomodoro-sound-file-path-pomo', widget.get_uri());
-        });
+        // widget.set_file(Gio.File.new_from_uri(this.settings.get_string('pomodoro-sound-file-path-pomo')));
+        // widget.prototype._onFileChooserResponse = (widget, response) => {
+        //     if (response !== Gtk.ResponseType.ACCEPT) {
+        //         return;
+        //     }
+        //     this.settings.set_string('pomodoro-sound-file-path-pomo', widget.get_file().get_uri());
+        // };
 
         widget = this.builder.get_object('pomodoro-sound-button-short-break');
-        widget.set_uri(this.settings.get_string('pomodoro-sound-file-path-short-break'));
-        widget.connect('selection-changed', (widget) => {
-            this.settings.set_string('pomodoro-sound-file-path-short-break', widget.get_uri());
-        });
+        // widget.set_file(Gio.File.new_from_uri(this.settings.get_string('pomodoro-sound-file-path-short-break')));
+        // widget.prototype._onFileChooserResponse = (widget, response) => {
+        //     if (response !== Gtk.ResponseType.ACCEPT) {
+        //         return;
+        //     }
+        //     this.settings.set_string('pomodoro-sound-file-path-short-break', widget.get_file().get_uri());
+        // };
 
         widget = this.builder.get_object('pomodoro-sound-button-long-break');
-        widget.set_uri(this.settings.get_string('pomodoro-sound-file-path-long-break'));
-        widget.connect('selection-changed', (widget) => {
-            this.settings.set_string('pomodoro-sound-file-path-long-break', widget.get_uri());
-        });
+        // widget.set_file(Gio.File.new_from_uri(this.settings.get_string('pomodoro-sound-file-path-long-break')));
+        // widget.prototype._onFileChooserResponse = (widget, response) => {
+        //     if (response !== Gtk.ResponseType.ACCEPT) {
+        //         return;
+        //     }
+        //     this.settings.set_string('pomodoro-sound-file-path-long-break', widget.get_file().get_uri());
+        // };
 
         this.settings.bind(
             'pomodoro-play-sound-pomo',
@@ -379,10 +412,13 @@ class Settings {
         }
 
         widget = this.builder.get_object('alarms-sound-button');
-        widget.set_uri(this.settings.get_string('alarms-sound-file-path'));
-        widget.connect('selection-changed', (widget) => {
-            this.settings.set_string('alarms-sound-file-path', widget.get_uri());
-        });
+        // widget.set_file(Gio.File.new_from_uri(this.settings.get_string('alarms-sound-file-path')));
+        // widget.prototype._onFileChooserResponse = (widget, response) => {
+        //     if (response !== Gtk.ResponseType.ACCEPT) {
+        //         return;
+        //     }
+        //     this.settings.set_string('alarms-sound-file-path', widget.get_file().get_uri());
+        // };
 
         widget = this.builder.get_object('alarms-notif-style-combo');
         widget.set_active(this.settings.get_enum('alarms-notif-style'));

--- a/prefs.js
+++ b/prefs.js
@@ -604,7 +604,6 @@ function buildPrefsWidget () {
         return false;
     });
 
-    widget.show_all();
     return widget;
 }
 


### PR DESCRIPTION
This PR fixes crashing of the extension settings.

I want to make exceptionally clear, that I did not yet use the extension. I just stumbled across it today and thought it was neat but had this issue to be addressed. Hence, I do not know if every feature still works as intended. Also, this is my first attempt at writing/contributing to Gnome extensions. Any help/improvements/tips are highly appreciated.

Closes #167