### PR TITLE
Bump supported shell-version 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
     "translations_url" : "https://github.com/zagortenay333/timepp__gnome/tree/master/data/po_files",
     "gettext-domain"   : "timepp",
     "version"          : -1,
-    "shell-version"    : ["3.36", "3.38", "40"],
+    "shell-version"    : ["3.36", "3.38", "40", "41"],
     "cache-file-format-version" : {
         "timer"     : 3,
         "stopwatch" : 4,


### PR DESCRIPTION
Simple version bump, no issues with gnome-shell version 41. GJS is still 1.65.1, no breaking changes found.
Related issue: #177 