### PR TITLE
fix #184

### DIFF
--- a/sections/todo/time_tracker.js
+++ b/sections/todo/time_tracker.js
@@ -255,7 +255,7 @@ var TimeTracker = class TimeTracker {
             }
 
             append_stream.write_all(contents, null);
-            this.daily_csv_file.replace_contents('', null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
+            this.daily_csv_file.replace_contents('\n', null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
         } catch (e) { logError(e); }
 
         this._enable_file_monitors();


### PR DESCRIPTION
There is a problem when passing an empty string to g_file_replace_contents:
```
(gnome-shell:258392): GLib-GIO-CRITICAL **: 20:34:02.627: g_file_replace_contents: assertion 'contents != NULL' failed

(gnome-shell:258392): GLib-GIO-CRITICAL **: 20:34:04.629: g_file_replace_contents: assertion 'contents != NULL' failed

(gnome-shell:258392): GLib-GIO-CRITICAL **: 20:34:06.630: g_file_replace_contents: assertion 'contents != NULL' failed

(gnome-shell:258392): GLib-GIO-CRITICAL **: 20:34:06.631: g_file_replace_contents: assertion 'contents != NULL' failed

(gnome-shell:258392): GLib-GIO-CRITICAL **: 20:34:08.051: g_file_replace_contents: assertion 'contents != NULL' failed

```
This, in turn, means that  _archive_daily_csv_file() never finishes. It executes up to the point where the daily csv file content is added to the yearly csv file, but it never clears up the daily csv file.
Since the function gets retried every 2 seconds, this quickly leads to hundreds of duplicated entries in the yearly csv file and complete system instability.
The fix consists in simply replacing the file content with a newline instead of an empty string