### PR TITLE
Resolve instability of file monitors

### DIFF
--- a/sections/todo/time_tracker.js
+++ b/sections/todo/time_tracker.js
@@ -321,16 +321,22 @@ var TimeTracker = class TimeTracker {
         if (this.daily_csv_file_monitor && this.daily_csv_file_monitor_id) {
             this.daily_csv_file_monitor.disconnect(this.daily_csv_file_monitor_id);
             this.daily_csv_file_monitor_id = 0;
+            this.daily_csv_file_monitor.cancel();
+            this.daily_csv_file_monitor = null;
         }
 
         if (this.yearly_csv_file_monitor && this.yearly_csv_file_monitor_id) {
             this.yearly_csv_file_monitor.disconnect(this.yearly_csv_file_monitor_id);
             this.yearly_csv_file_monitor_id = 0;
+            this.yearly_csv_file_monitor.cancel();
+            this.yearly_csv_file_monitor = null;
         }
 
         if (this.yearly_csv_dir_monitor && this.yearly_csv_dir_monitor_id) {
             this.yearly_csv_dir_monitor.disconnect(this.yearly_csv_dir_monitor_id);
             this.yearly_csv_dir_monitor_id = 0;
+            this.yearly_csv_dir_monitor.cancel();
+            this.yearly_csv_dir_monitor = null;
         }
     }
 
@@ -793,20 +799,7 @@ var TimeTracker = class TimeTracker {
             this.enable_file_monitors_timeout_id = 0;
         }
 
-        if (this.daily_csv_file_monitor) {
-            this.daily_csv_file_monitor.cancel();
-            this.daily_csv_file_monitor = null;
-        }
-
-        if (this.yearly_csv_file_monitor) {
-            this.yearly_csv_file_monitor.cancel();
-            this.yearly_csv_file_monitor = null;
-        }
-
-        if (this.yearly_csv_dir_monitor) {
-            this.yearly_csv_dir_monitor.cancel();
-            this.yearly_csv_dir_monitor = null;
-        }
+        this._disable_file_monitors();
 
         if (this.new_day_sig_id) this.delegate.disconnect(this.new_day_sig_id);
         if (this.todo_current_sig_id) this.delegate.settings.disconnect(this.todo_current_sig_id);

--- a/sections/todo/time_tracker.js
+++ b/sections/todo/time_tracker.js
@@ -255,7 +255,7 @@ var TimeTracker = class TimeTracker {
             }
 
             append_stream.write_all(contents, null);
-            this.daily_csv_file.replace_contents('', null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
+            this.daily_csv_file.replace_contents('\n', null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
         } catch (e) { logError(e); }
 
         this._enable_file_monitors();


### PR DESCRIPTION
Apparently my previous fix for #184 is not complete. There are still random occurrences where the extension freezes the system. I've tracked down the following log when it happens:
```
gen 03 14:17:46 powersource3 gnome-shell[2863]: Attempting to call back into JSAPI during the sweeping phase of GC. This is most likely caused by not destroying a Clutter actor or Gtk+ widget with ::destroy signals connected, but can also be caused by using the destroy(), dispose(), or remove() vfuncs. Because it would crash the application, it has been blocked and the JS callback not invoked.
gen 03 14:17:46 powersource3 gnome-shell[2863]: The offending signal was changed on GInotifyFileMonitor 0x561b678c19f0.
gen 03 14:17:46 powersource3 gnome-shell[2863]: == Stack trace for context 0x561b639bb1b0 ==
```
This was already reported in #121 but no corrective action was taken.

It appears that a wrong memory management is done on the monitors. So, if in `_disable_file_monitors()` we completely cancel them and recreate them again in  `_enable_file_monitors()`, the issues is solved. After the fix, I've been using the extension continually for around 2 days without any freeze.