### PR TITLE
Bump supported shell-version 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
     "translations_url" : "https://github.com/zagortenay333/timepp__gnome/tree/master/data/po_files",
     "gettext-domain"   : "timepp",
     "version"          : -1,
-    "shell-version"    : ["40", "41"],
+    "shell-version"    : ["40", "41", "42"],
     "cache-file-format-version" : {
         "timer"     : 3,
         "stopwatch" : 4,


### PR DESCRIPTION
Simple version bump, no issues with gnome-shell version 42. Some breaking changes found.
Related issue: #190
Only the stopwatch works correctly...