### PR TITLE
GNOME 42 compatibility + removal of fullscreen buttons 

### DIFF
--- a/data/prefs.ui
+++ b/data/prefs.ui
@@ -12,6 +12,9 @@
     <property name="height_request">500</property>
     <property name="orientation">vertical</property>
     <child>
+      <object class="GtkHeaderBar" id="header_bar"/>
+    </child>
+    <child>
       <object class="GtkStack" id="settings_stack">
         <property name="vexpand">1</property>
         <property name="transition_type">slide-left-right</property>

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
     "translations_url" : "https://github.com/zagortenay333/timepp__gnome/tree/master/data/po_files",
     "gettext-domain"   : "timepp",
     "version"          : -1,
-    "shell-version"    : ["40", "41"],
+    "shell-version"    : ["40", "41", "42"],
     "cache-file-format-version" : {
         "timer"     : 3,
         "stopwatch" : 4,

--- a/prefs.js
+++ b/prefs.js
@@ -546,11 +546,8 @@ class Settings {
     _set_headerbar() {
             this.widget.connect('realize', () => {
             let window = this.widget.get_root();
-            //let headerBar = new Gtk.HeaderBar();
             let headerBar = this.builder.get_object('header_bar');
             headerBar.set_title_widget(this.switcher);
-            //window.set_title("testing");
-            //window.set_titlebar(headerBar);
             return false;
         });
     }

--- a/prefs.js
+++ b/prefs.js
@@ -546,9 +546,10 @@ class Settings {
     _set_headerbar() {
             this.widget.connect('realize', () => {
             let window = this.widget.get_root();
-            let headerBar = new Gtk.HeaderBar();
+            //let headerBar = new Gtk.HeaderBar();
+            let headerBar = this.builder.get_object('header_bar');
             headerBar.set_title_widget(this.switcher);
-            window.set_title("testing");
+            //window.set_title("testing");
             //window.set_titlebar(headerBar);
             return false;
         });

--- a/prefs.js
+++ b/prefs.js
@@ -114,7 +114,7 @@ class Settings {
 
         widget = this.builder.get_object('timer-sound-button');
         widget.connect('clicked', (widget) => this._open_file_chooser(widget, 'timer-sound-file-path'));
-        
+
 
         widget = this.builder.get_object('timer-notif-style-combo');
         widget.set_active(this.settings.get_enum('timer-notif-style'));
@@ -544,11 +544,12 @@ class Settings {
     }
 
     _set_headerbar() {
-        this.widget.connect('realize', () => {
+            this.widget.connect('realize', () => {
             let window = this.widget.get_root();
             let headerBar = new Gtk.HeaderBar();
             headerBar.set_title_widget(this.switcher);
-            window.set_titlebar(headerBar);
+            window.set_title("testing");
+            //window.set_titlebar(headerBar);
             return false;
         });
     }

--- a/sections/pomodoro.js
+++ b/sections/pomodoro.js
@@ -157,8 +157,9 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         this.icon_box = new St.BoxLayout({ y_align: Clutter.ActorAlign.CENTER, x_align: Clutter.ActorAlign.END, style_class: 'icon-box' });
         this.header.add_actor(this.icon_box);
 
-        this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.get_icon('timepp-fullscreen-symbolic'), style_class: 'fullscreen-icon' });
-        this.icon_box.add_actor(this.fullscreen_icon);
+        // LANDEGT: REMOVING FULLSCREEN ICON BECAUSE OF BUGS
+        // this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.get_icon('timepp-fullscreen-symbolic'), style_class: 'fullscreen-icon' });
+        // this.icon_box.add_actor(this.fullscreen_icon);
 
         this.settings_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.get_icon('timepp-settings-symbolic'), style_class: 'settings-icon' });
         this.icon_box.add_actor(this.settings_icon);
@@ -199,7 +200,8 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         this.sigm.connect(this.settings, 'changed::pomodoro-panel-mode', () => this._toggle_panel_mode());
         this.sigm.connect(this.panel_item, 'middle-click', () => this.timer_toggle());
         this.sigm.connect_release(this.settings_icon, Clutter.BUTTON_PRIMARY, true, () => this._show_settings());
-        this.sigm.connect_release(this.fullscreen_icon, Clutter.BUTTON_PRIMARY, true, () => this.show_fullscreen());
+        // LANDEGT: REMOVING ACTION FROM FULLSCREEN ICON
+        // this.sigm.connect_release(this.fullscreen_icon, Clutter.BUTTON_PRIMARY, true, () => this.show_fullscreen());
         this.sigm.connect_release(this.button_continue, Clutter.BUTTON_PRIMARY, true, () => this.start_pomo());
         this.sigm.connect_release(this.button_stop, Clutter.BUTTON_PRIMARY, true, () => this.stop());
         this.sigm.connect_release(this.button_new_pomo, Clutter.BUTTON_PRIMARY, true, () => this.start_new_pomo());

--- a/sections/stopwatch.js
+++ b/sections/stopwatch.js
@@ -151,8 +151,9 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         this.icon_box = new St.BoxLayout({ y_align: Clutter.ActorAlign.CENTER, x_align: Clutter.ActorAlign.END, style_class: 'icon-box' });
         this.header.add_child(this.icon_box);
 
-        this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.get_icon('timepp-fullscreen-symbolic'), style_class: 'fullscreen-icon' });
-        this.icon_box.add_actor(this.fullscreen_icon);
+        // LANDEGT: REMOVING FULLSCREEN ICON BECAUSE OF BUGS
+        // this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.get_icon('timepp-fullscreen-symbolic'), style_class: 'fullscreen-icon' });
+        // this.icon_box.add_actor(this.fullscreen_icon);
 
         //
         // buttons
@@ -207,7 +208,8 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         });
         this.sigm.connect(this.settings, 'changed::stopwatch-panel-mode', () => this._toggle_panel_mode());
         this.sigm.connect(this.panel_item, 'middle-click', () => this.stopwatch_toggle());
-        this.sigm.connect_release(this.fullscreen_icon, Clutter.BUTTON_PRIMARY, true, () => this.show_fullscreen());
+        // LANDEGT: REMOVING FULLSCREEN ICON BECAUSE OF BUGS
+        // this.sigm.connect_release(this.fullscreen_icon, Clutter.BUTTON_PRIMARY, true, () => this.show_fullscreen());
         this.sigm.connect_release(this.button_start, Clutter.BUTTON_PRIMARY, true, () => this.start());
         this.sigm.connect_release(this.button_reset, Clutter.BUTTON_PRIMARY, true, () => this.reset());
         this.sigm.connect_release(this.button_stop, Clutter.BUTTON_PRIMARY, true, () => this.stop());

--- a/sections/timer.js
+++ b/sections/timer.js
@@ -165,8 +165,9 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         this.start_pause_icon = new St.Icon({ visible: false, reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.get_icon('timepp-pause-symbolic'), style_class: 'pause-icon' });
         this.icon_box.add_actor(this.start_pause_icon);
 
-        this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.get_icon('timepp-fullscreen-symbolic'), style_class: 'fullscreen-icon' });
-        this.icon_box.add_actor(this.fullscreen_icon);
+        // LANDEGT: REMOVING FULLSCREEN ICON BECAUSE OF BUGS
+        // this.fullscreen_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.get_icon('timepp-fullscreen-symbolic'), style_class: 'fullscreen-icon' });
+        // this.icon_box.add_actor(this.fullscreen_icon);
 
         this.settings_icon = new St.Icon({ reactive: true, can_focus: true, track_hover: true, gicon : MISC_UTILS.get_icon('timepp-settings-symbolic'), style_class: 'settings-icon' });
         this.icon_box.add(this.settings_icon);
@@ -199,7 +200,8 @@ var SectionMain = class SectionMain extends ME.imports.sections.section_base.Sec
         this.sigm.connect(this.settings, 'changed::timer-panel-mode', () => this._toggle_panel_item_mode());
         this.sigm.connect(this.panel_item, 'middle-click', () => this.toggle_timer());
         this.sigm.connect_release(this.start_pause_icon, Clutter.BUTTON_PRIMARY, true, () => this.toggle_timer());
-        this.sigm.connect_release(this.fullscreen_icon, Clutter.BUTTON_PRIMARY, true, () => this.show_fullscreen());
+        // LANDEGT: REMOVING FULLSCREEN ICON BECAUSE OF BUGS
+        // this.sigm.connect_release(this.fullscreen_icon, Clutter.BUTTON_PRIMARY, true, () => this.show_fullscreen());
         this.sigm.connect_release(this.settings_icon, Clutter.BUTTON_PRIMARY, true, () => this._show_presets());
         this.sigm.connect(this.slider, 'notify::value', () => this.slider_changed(this.slider.value));
         this.sigm.connect(this.slider, 'drag-end', () => this.slider_released());


### PR DESCRIPTION
I believe I've fixed the main (/only one I found) compatibility issue with GNOME42  (#190) : the preferences/settings menu. The call set_titlebar()  is not supported by libadwaita; this is resolved by adding the headerBar as its own object as recommended in the libadwaita documentation. 

In addition, I have removed the fullscreen buttons as this has been buggy for quite some time and doesn't seem to have an easy fix (https://github.com/zagortenay333/timepp/issues/179#issuecomment-979915164). 