### PR TITLE
Fix phase dropdown not working in GNOME Shell 46.0 (fixes #272)

### DIFF
--- a/data/metadata.json
+++ b/data/metadata.json
@@ -3,6 +3,6 @@
     "uuid":           "cronomix@zagortenay333",
     "url":            "https://github.com/zagortenay333/cronomix",
     "description":    "All-in-one timer, stopwatch, pomodoro, alarm, todo, and flashcards extension",
-    "shell-version":  ["49"],
+    "shell-version":  ["46", "49"],
     "gettext-domain": "cronomix"
 }

--- a/src/utils/pickers.ts
+++ b/src/utils/pickers.ts
@@ -263,7 +263,12 @@ export class Dropdown {
 
                 button.subscribe('left_click', () => {
                     this.actor.set_label(display_value);
-                    popup.close();
+                    try{
+                        popup.close();
+                    }catch(e){
+                        //- The popup might have already been destroyed because it lost focus
+                        // logError(e);
+                    }
                     this.on_change?.(values[idx]);
                 });
             }


### PR DESCRIPTION
Selecting a phase gave the following error:

```
Object .Gjs_ui_boxpointer_BoxPointer (0x62d47dfe32e0), has been already disposed — impossible to access it. This might be caused by the object having been destroyed from C code using something such as destroy(), dispose(), or remove() vfuncs.
```

which suggests that the popup was already gone by the time `popup.close()` method was called. Because it probably worked fine with other Gnome version I wrapped it in a `try-catch` block.